### PR TITLE
対局中に学習を進めるLearnCommanderを実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -276,3 +276,5 @@ FiveSquareShogi/.VSCodeCounter/
 FiveSquareShogi/data/
 
 FiveSquareShogi/log.txt
+
+FiveSquareShogi/learning/

--- a/FiveSquareShogi.sln
+++ b/FiveSquareShogi.sln
@@ -9,6 +9,10 @@ Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86
+		LearnCommander-Debug|x64 = LearnCommander-Debug|x64
+		LearnCommander-Debug|x86 = LearnCommander-Debug|x86
+		LearnCommander-Release|x64 = LearnCommander-Release|x64
+		LearnCommander-Release|x86 = LearnCommander-Release|x86
 		Learn-Debug|x64 = Learn-Debug|x64
 		Learn-Debug|x86 = Learn-Debug|x86
 		Learn-Release|x64 = Learn-Release|x64
@@ -21,6 +25,14 @@ Global
 		{1D3E44C9-6AFE-4C7A-8248-687CA93348E9}.Debug|x64.Build.0 = Debug|x64
 		{1D3E44C9-6AFE-4C7A-8248-687CA93348E9}.Debug|x86.ActiveCfg = Debug|Win32
 		{1D3E44C9-6AFE-4C7A-8248-687CA93348E9}.Debug|x86.Build.0 = Debug|Win32
+		{1D3E44C9-6AFE-4C7A-8248-687CA93348E9}.LearnCommander-Debug|x64.ActiveCfg = LearnCommander-Debug|x64
+		{1D3E44C9-6AFE-4C7A-8248-687CA93348E9}.LearnCommander-Debug|x64.Build.0 = LearnCommander-Debug|x64
+		{1D3E44C9-6AFE-4C7A-8248-687CA93348E9}.LearnCommander-Debug|x86.ActiveCfg = LearnCommander-Debug|Win32
+		{1D3E44C9-6AFE-4C7A-8248-687CA93348E9}.LearnCommander-Debug|x86.Build.0 = LearnCommander-Debug|Win32
+		{1D3E44C9-6AFE-4C7A-8248-687CA93348E9}.LearnCommander-Release|x64.ActiveCfg = LeaernCommander-Release|x64
+		{1D3E44C9-6AFE-4C7A-8248-687CA93348E9}.LearnCommander-Release|x64.Build.0 = LeaernCommander-Release|x64
+		{1D3E44C9-6AFE-4C7A-8248-687CA93348E9}.LearnCommander-Release|x86.ActiveCfg = LeaernCommander-Release|Win32
+		{1D3E44C9-6AFE-4C7A-8248-687CA93348E9}.LearnCommander-Release|x86.Build.0 = LeaernCommander-Release|Win32
 		{1D3E44C9-6AFE-4C7A-8248-687CA93348E9}.Learn-Debug|x64.ActiveCfg = Learn-Debug|x64
 		{1D3E44C9-6AFE-4C7A-8248-687CA93348E9}.Learn-Debug|x64.Build.0 = Learn-Debug|x64
 		{1D3E44C9-6AFE-4C7A-8248-687CA93348E9}.Learn-Debug|x86.ActiveCfg = Learn-Debug|Win32

--- a/FiveSquareShogi/FiveSquareShogi.vcxproj
+++ b/FiveSquareShogi/FiveSquareShogi.vcxproj
@@ -5,6 +5,14 @@
       <Configuration>Debug</Configuration>
       <Platform>Win32</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="LeaernCommander-Release|Win32">
+      <Configuration>LeaernCommander-Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="LeaernCommander-Release|x64">
+      <Configuration>LeaernCommander-Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Learn-Debug|Win32">
       <Configuration>Learn-Debug</Configuration>
       <Platform>Win32</Platform>
@@ -19,6 +27,14 @@
     </ProjectConfiguration>
     <ProjectConfiguration Include="Learn-Release|x64">
       <Configuration>Learn-Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="LearnCommander-Debug|Win32">
+      <Configuration>LearnCommander-Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="LearnCommander-Debug|x64">
+      <Configuration>LearnCommander-Debug</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
     <ProjectConfiguration Include="Release|Win32">
@@ -54,6 +70,12 @@
     <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='LearnCommander-Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
@@ -68,6 +90,13 @@
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='LeaernCommander-Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
@@ -75,6 +104,12 @@
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Learn-Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='LearnCommander-Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v142</PlatformToolset>
@@ -94,6 +129,13 @@
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='LeaernCommander-Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
@@ -105,10 +147,16 @@
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Learn-Debug|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='LearnCommander-Debug|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Learn-Release|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='LeaernCommander-Release|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -117,10 +165,16 @@
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Learn-Debug|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='LearnCommander-Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Learn-Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='LeaernCommander-Release|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
@@ -130,10 +184,16 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Learn-Debug|Win32'">
     <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='LearnCommander-Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Learn-Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='LearnCommander-Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -142,11 +202,18 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Learn-Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='LeaernCommander-Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
     <EmbedManifest>false</EmbedManifest>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Learn-Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <EmbedManifest>false</EmbedManifest>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='LeaernCommander-Release|x64'">
     <LinkIncremental>false</LinkIncremental>
     <EmbedManifest>false</EmbedManifest>
   </PropertyGroup>
@@ -158,6 +225,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -170,8 +238,24 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_LEARN;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='LearnCommander-Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_LEARN;_LEARN_COMMANDER;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -208,6 +292,21 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
   </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='LearnCommander-Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;_LEARN;_LEARN_COMMANDER;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
       <PrecompiledHeader>
@@ -218,6 +317,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -234,8 +334,28 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_LEARN;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='LeaernCommander-Release|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_LEARN;_LEARN_COMMANDER;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -284,6 +404,26 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
   </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='LeaernCommander-Release|x64'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;_LEARN;_LEARN_COMMANDER;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <EnableEnhancedInstructionSet>AdvancedVectorExtensions2</EnableEnhancedInstructionSet>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="agent.cpp" />
     <ClCompile Include="commander.cpp" />
@@ -299,18 +439,22 @@
     <ClCompile Include="kyokumen.cpp" />
     <ClCompile Include="leaf_guard.cpp" />
     <ClCompile Include="learner.cpp" />
+    <ClCompile Include="learn_agent.cpp" />
+    <ClCompile Include="learn_commander.cpp" />
     <ClCompile Include="learn_method.cpp" />
     <ClCompile Include="learn_util.cpp" />
     <ClCompile Include="main.cpp" />
     <ClCompile Include="move.cpp" />
     <ClCompile Include="move_gen.cpp" />
     <ClCompile Include="node.cpp" />
+    <ClCompile Include="random.cpp" />
     <ClCompile Include="stdafx.cpp" />
     <ClCompile Include="stest.cpp" />
     <ClCompile Include="temperature.cpp" />
     <ClCompile Include="time_property.cpp" />
     <ClCompile Include="tree.cpp" />
     <ClCompile Include="usi.cpp" />
+    <ClCompile Include="simulation.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="agent.h" />
@@ -331,12 +475,16 @@
     <ClInclude Include="kyokumen.h" />
     <ClInclude Include="leaf_guard.h" />
     <ClInclude Include="learner.h" />
+    <ClInclude Include="learn_agent.h" />
+    <ClInclude Include="learn_commander.h" />
     <ClInclude Include="learn_method.h" />
     <ClInclude Include="learn_util.h" />
     <ClInclude Include="move.h" />
     <ClInclude Include="move_gen.h" />
     <ClInclude Include="node.h" />
     <ClInclude Include="player.h" />
+    <ClInclude Include="random.h" />
+    <ClInclude Include="simulation.h" />
     <ClInclude Include="stdafx.h" />
     <ClInclude Include="stest.h" />
     <ClInclude Include="temperature.h" />

--- a/FiveSquareShogi/FiveSquareShogi.vcxproj.filters
+++ b/FiveSquareShogi/FiveSquareShogi.vcxproj.filters
@@ -78,9 +78,6 @@
     <ClCompile Include="kppt_feature.cpp">
       <Filter>kppt</Filter>
     </ClCompile>
-    <ClCompile Include="move_gen.cpp">
-      <Filter>ソース ファイル\search</Filter>
-    </ClCompile>
     <ClCompile Include="leaf_guard.cpp">
       <Filter>ソース ファイル\search</Filter>
     </ClCompile>
@@ -118,6 +115,21 @@
       <Filter>ソース ファイル\learn</Filter>
     </ClCompile>
     <ClCompile Include="temperature.cpp">
+      <Filter>ソース ファイル\search</Filter>
+    </ClCompile>
+    <ClCompile Include="learn_agent.cpp">
+      <Filter>ソース ファイル\learn</Filter>
+    </ClCompile>
+    <ClCompile Include="random.cpp">
+      <Filter>ソース ファイル\kiso</Filter>
+    </ClCompile>
+    <ClCompile Include="simulation.cpp">
+      <Filter>ソース ファイル\search</Filter>
+    </ClCompile>
+    <ClCompile Include="learn_commander.cpp">
+      <Filter>ソース ファイル\learn</Filter>
+    </ClCompile>
+    <ClCompile Include="move_gen.cpp">
       <Filter>ソース ファイル\search</Filter>
     </ClCompile>
   </ItemGroup>
@@ -214,6 +226,18 @@
     </ClInclude>
     <ClInclude Include="temperature.h">
       <Filter>ヘッダー ファイル\search</Filter>
+    </ClInclude>
+    <ClInclude Include="learn_agent.h">
+      <Filter>ヘッダー ファイル\learn</Filter>
+    </ClInclude>
+    <ClInclude Include="random.h">
+      <Filter>ヘッダー ファイル\kiso</Filter>
+    </ClInclude>
+    <ClInclude Include="simulation.h">
+      <Filter>ヘッダー ファイル\search</Filter>
+    </ClInclude>
+    <ClInclude Include="learn_commander.h">
+      <Filter>ヘッダー ファイル\learn</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/FiveSquareShogi/agent.h
+++ b/FiveSquareShogi/agent.h
@@ -3,9 +3,12 @@
 #include "move_gen.h"
 #include "kppt_evaluate.h"
 #include "temperature.h"
+#include "random.h"
 #include <random>
 #include <thread>
 #include <functional>
+
+//#define EXPAND_GRANDCHILDREN //探索での展開時に孫ノードまで展開するオプション
 
 class SearchAgent {
 public:
@@ -19,7 +22,7 @@ private:
 		search, gc, terminate
 	};
 public:
-	SearchAgent(SearchTree& tree, const double Ts, int seed);
+	SearchAgent(SearchTree& tree, const double Ts, const Random::xoshiro256p& seed);
 	SearchAgent(SearchAgent&&)noexcept;
 	~SearchAgent();
 	SearchAgent() = delete;
@@ -30,6 +33,7 @@ public:
 private:
 	void simulate(SearchNode* const root);
 	size_t qsimulate(SearchNode* const root, SearchPlayer& player, const int hislength);
+	bool checkRepetition(SearchNode* const node, const Kyokumen& kyokumen, const std::vector<SearchNode*>& history, const std::vector<std::pair<std::uint64_t, Bammen>>& k_history);
 	bool checkRepetitiveCheck(const Kyokumen& k, const std::vector<SearchNode*>& searchhis, const SearchNode* const latestRepnode)const;
 	bool deleteGarbage();
 
@@ -45,8 +49,7 @@ private:
 	static std::atomic_uint old_threads_num;
 
 	//値域 [0,1.0) のランダムな値
-	std::uniform_real_distribution<double> random{ 0, 1.0 };
-	std::mt19937_64 engine; //初期シードはコンストラクタで受け取る
+	Random::xoshiro256p random; //初期シードはコンストラクタで受け取る
 
 	friend class ShogiTest;
 	friend class AgentPool;

--- a/FiveSquareShogi/commander.h
+++ b/FiveSquareShogi/commander.h
@@ -6,7 +6,7 @@
 class Commander {
 public:
 	static void execute(const std::string&);
-private:
+protected:
 	Commander();
 	~Commander();
 	static void coutOption();
@@ -19,6 +19,8 @@ private:
 	void info();
 	void chakushu(SearchNode* const bestmove);
 	void position(const std::vector<std::string>& tokens);
+
+	void showKifuFigure();
 
 	SearchTree tree;
 	AgentPool agents{ tree };

--- a/FiveSquareShogi/kppt_evaluate.cpp
+++ b/FiveSquareShogi/kppt_evaluate.cpp
@@ -6,8 +6,8 @@
 
 namespace kppt {
 
-	std::string kppt_evaluator::ifolderpath = "data/learn/kppt";
-	std::string kppt_evaluator::ofolderpath = "data/learn/kppt";
+	std::string kppt_evaluator::ifolderpath = "data/kppt";
+	std::string kppt_evaluator::ofolderpath = "data/kppt";
 
 	void kppt_evaluator::init() {
 		kppt_feat::init(ifolderpath);
@@ -65,6 +65,18 @@ namespace kppt {
 				fs.write(it, size);
 			}
 		}
+		if (dynamicPieceScore) {
+			const std::array<PieceScoreType, static_cast<size_t>(koma::Koma::KomaNum)> PieceScoreArr = { 0 };
+			std::ofstream fs(folderpath + "/Piece.bin", std::ios::binary);
+			if (fs) {
+				for (auto& p : PieceScoreArr) {
+					fs.write((char*)&p, sizeof(p));
+				}
+			}
+			else {
+				std::cerr << "error:file(" << folderpath << "/Piece.bin) cannot open" << std::endl;
+			}
+		}
 	}
 
 	void kppt_evaluator::print(int iskpp) {
@@ -92,5 +104,6 @@ namespace kppt {
 				}
 			}
 		}
+
 	}
 }

--- a/FiveSquareShogi/kppt_evaluate.h
+++ b/FiveSquareShogi/kppt_evaluate.h
@@ -14,6 +14,9 @@ namespace kppt {
 
 		static void setpath_input(const std::string& path) { ifolderpath = path; }
 		static void setpath_output(const std::string& path) { ofolderpath = path; }
+		static const std::string& getpath_input() { return ifolderpath; }
+		static const std::string& getpath_output() { return ofolderpath; }
+		static void use_dynamicPieceScore(const bool b) { dynamicPieceScore = b; }
 		
 		static void genFirstEvalFile(const std::string& folderpath);
 

--- a/FiveSquareShogi/kppt_feature.h
+++ b/FiveSquareShogi/kppt_feature.h
@@ -1,8 +1,22 @@
 ﻿#pragma once
 #include "kppt_param.h"
 
+#ifdef _LEARN
+#ifndef _LEARN_COMMANDER
+#define _EVAL_FLOAT
+#endif
+#endif
+
 namespace kppt {
+#ifndef _EVAL_FLOAT
+	using PieceScoreType = int;
+	using EvalElementTypeh = std::int16_t;
 	using EvalElementType = std::array<int16_t, 2>;
+#else
+	using PieceScoreType = float;
+	using EvalElementTypeh = float;
+	using EvalElementType = std::array<float, 2>;
+#endif
 	using KPPEvalElementType0 = EvalElementType[fe_end];
 	using KPPEvalElementType1 = KPPEvalElementType0[fe_end];
 	using KPPEvalElementType2 = KPPEvalElementType1[SquareNum];
@@ -10,9 +24,10 @@ namespace kppt {
 	using KKPEvalElementType1 = KKPEvalElementType0[SquareNum];
 	using KKPEvalElementType2 = KKPEvalElementType1[SquareNum];
 
-	extern std::array<int, static_cast<size_t>(koma::Koma::KomaNum)> PieceScoreArr;
+	extern std::array<PieceScoreType, static_cast<size_t>(koma::Koma::KomaNum)> PieceScoreArr;
 	extern KPPEvalElementType1* KPP;
 	extern KKPEvalElementType1* KKP;
+	extern bool dynamicPieceScore;
 	extern bool allocated;
 	inline int PieceScore(koma::Koma k) { return PieceScoreArr[static_cast<size_t>(k)]; }
 	inline int PieceScore(koma::Mochigoma m) { return PieceScoreArr[static_cast<size_t>(m)]; }
@@ -53,12 +68,12 @@ namespace kppt {
 		EvalSum operator-(const EvalSum& rhs) { return EvalSum(*this) -= rhs; }
 	};
 
-	inline std::array<std::int32_t, 2> operator += (std::array<std::int32_t, 2>& lhs, const std::array<std::int16_t, 2>& rhs) {
+	inline std::array<std::int32_t, 2> operator += (std::array<std::int32_t, 2>& lhs, const EvalElementType& rhs) {
 		lhs[0] += rhs[0];
 		lhs[1] += rhs[1];
 		return lhs;
 	}
-	inline std::array<std::int32_t, 2> operator -= (std::array<std::int32_t, 2>& lhs, const std::array<std::int16_t, 2>& rhs) {
+	inline std::array<std::int32_t, 2> operator -= (std::array<std::int32_t, 2>& lhs, const EvalElementType& rhs) {
 		lhs[0] -= rhs[0];
 		lhs[1] -= rhs[1];
 		return lhs;

--- a/FiveSquareShogi/kppt_learn.h
+++ b/FiveSquareShogi/kppt_learn.h
@@ -6,6 +6,8 @@
 namespace kppt {
 	constexpr size_t lkpptnum = SquareNum * fe_end * (fe_end - 1); //kpptテーブルのppの被りを消した三角テーブルを一次元にしている セル数はSQnum*(fe*(fe-1)/2)*2
 	constexpr size_t lkkptnum = SquareNum * SquareNum * fe_end * 2;//こちらは先後の区別があるため単純に一次元にしている
+	constexpr size_t lpiecenum_plain = 5; //成り駒を除いた駒の数
+	constexpr size_t lpiecenum = 9; //歩、銀、角、飛、金、と金、成銀、馬、龍 で9つ
 	using EvalVectorFloat = float;
 	using KPPEvalVectorFloat = EvalVectorFloat[lkpptnum];
 	using KKPEvalVectorFloat = EvalVectorFloat[lkkptnum];
@@ -27,6 +29,7 @@ namespace kppt {
 		kppt_evaluator& operator=(const kppt_paramVector&) = delete;
 
 		void reset();
+		void piece_addGrad(const float scalar, const Kyokumen&);
 		void addGrad(const float scalar,const SearchPlayer&);
 		void clamp(float absmax);
 
@@ -34,6 +37,7 @@ namespace kppt {
 		void save(const std::string& path);//勾配ファイルを出力
 		void load(const std::string& path);//勾配ファイルを読み込む
 	private:
+		std::array<EvalVectorFloat, lpiecenum> PieceScoreArr;
 		EvalVectorFloat* KPP;
 		EvalVectorFloat* KKP;
 		 
@@ -45,11 +49,28 @@ namespace kppt {
 		kppt_paramVector& operator+=(const fvpair& rhs);
 		kppt_paramVector& operator*=(const double c);
 
+		bool operator==(const kppt_paramVector& rhs)const;
+		bool operator!=(const kppt_paramVector& rhs)const { return !operator==(rhs); }
 		void print(double displaymin,int isKPP)const;
 	
 		friend class kppt_learn;
+		friend class Adam;
 		friend class ShogiTest;
 	};
 	inline kppt_paramVector::fvpair operator*(const float lhs, const kppt_paramVector& rhs) { return kppt_paramVector::fvpair(lhs,rhs); }
 
+	class Adam {
+	public:
+		void updateEval(kppt_paramVector& dw);
+		void save(const std::string& folderpath);
+		void load(const std::string& folderpath);
+
+		kppt_paramVector mt;
+		kppt_paramVector vt;
+		long long t = 0;
+		const double b1 = 0.9;
+		const double b2 = 0.999;
+		const double epsilon = 1.0e-8;
+		const double alpha = 1 / FVScale;
+	};
 }

--- a/FiveSquareShogi/kyokumen.h
+++ b/FiveSquareShogi/kyokumen.h
@@ -38,6 +38,12 @@ public:
 	std::vector<Bitboard> getSenteOuCheck()const;//盤全体をチェック
 	std::vector<Bitboard> getGoteOuCheck()const;
 
+	bool isOute(const Move& m = Move())const;
+	bool isSenteOute(const Move)const;
+	bool isGoteOute(const Move)const;
+	bool isSenteOute()const;
+	bool isGoteOute()const;
+
 	Bitboard pinMaskSente(const unsigned pos)const;//pos上の駒が敵駒にpinされていれば移動可能な直線範囲を返す pinされてなければAllOneが返る
 	Bitboard pinMaskGote(const unsigned pos)const;
 	Bitboard senteKiki_ingnoreKing()const;

--- a/FiveSquareShogi/learn_agent.cpp
+++ b/FiveSquareShogi/learn_agent.cpp
@@ -1,0 +1,361 @@
+﻿#include "stdafx.h"
+#include "learn_agent.h"
+#include "leaf_guard.h"
+
+int LearnAgent::drawmovenum = 320;
+
+LearnAgent::LearnAgent(const Random::xoshiro256p& random)
+	: random(random), th(&LearnAgent::loop, this)
+{}
+
+void LearnAgent::start() {
+	status = State::search;
+	cv.notify_all();
+}
+
+void LearnAgent::stop() {
+	status = State::pause;
+}
+
+void LearnAgent::deleteTree() {
+	status = State::del;
+}
+
+void LearnAgent::join() {
+	//status = State::pause;
+	std::lock_guard<std::mutex> _lock(mtx);
+}
+
+void LearnAgent::loop() {
+	inSearch = false;
+	status = State::pause;
+	while (status != State::terminate) {
+		switch (status)
+		{
+			case State::pause:
+			{
+				std::unique_lock<std::mutex> _lock(mtx);
+				inSearch = false;
+				cv.wait(_lock);
+			}
+				break;
+			case State::search:
+				inSearch = true;
+				search();
+				break;
+			case State::del:
+				inSearch = true;
+				del();
+				break;
+		}
+	}
+	inSearch = false;
+}
+
+void LearnAgent::search() {
+	using dn = std::pair<double, SearchNode*>;
+	using dd = std::pair<double, double>;
+	const double T_e = SearchTemperature::Te;
+	const double T_d = SearchTemperature::Td;
+	const double MateScoreBound = SearchNode::getMateScoreBound();
+	SearchNode* node = tree->getRoot();
+	SearchPlayer player = tree->getRootPlayer();
+	std::vector<SearchNode*> history = { node };
+	std::vector<std::pair<uint64_t, Bammen>> k_history;
+	//選択
+	while (!node->isLeaf()) {
+		double CE = std::numeric_limits<double>::max();
+		std::vector<dn> evals; evals.reserve(node->children.size());
+		for (auto& child : node->children) {
+			if (child.isSearchable()) {
+				double eval = child.getEs();
+				evals.push_back(std::make_pair(eval, &child));
+				if (eval < CE) {
+					CE = eval;
+				}
+			}
+		}
+		if (evals.empty()) {
+			//node->status = SearchNode::State::Terminal;
+			if (history.size() == 1) {
+				using namespace std::chrono_literals;
+				std::this_thread::sleep_for(200us);
+			}
+			return;
+		}
+		const double T_c = SearchTemperature::getTs_atNode(Ts, *node);
+		double Z = 0;
+		for (const auto& eval : evals) {
+			Z += std::exp(-(eval.first - CE) / T_c);
+		}
+		double pip = Z * random.rand01();
+		node = evals.front().second;
+		for (const auto& eval : evals) {
+			pip -= std::exp(-(eval.first - CE) / T_c);
+			if (pip <= 0) {
+				node = eval.second;
+				break;
+			}
+		}
+		//局面を進める
+		k_history.push_back(std::make_pair(player.kyokumen.getHash(), player.kyokumen.getBammen()));
+		player.proceed(node->move);
+		history.push_back(node);
+	}
+	//展開・評価
+	{
+		//末端ノードが他スレッドで展開中になっていないかチェック
+		LeafGuard dredear(node);
+		if (!dredear.Result()) {
+			return;
+		}
+		//千日手チェック
+		unsigned repnum = 0;
+		SearchNode* repnode = nullptr;
+		SearchNode* latestRepnode = nullptr;
+		{
+			auto p = tree->findRepetition(player.kyokumen);
+			repnum += p.first;
+			repnode = p.second;
+			const auto hash = player.kyokumen.getHash();
+			//先後一致している方のみを調べればよいので1つ飛ばしで調べる
+			for (int t = k_history.size() - 2; t >= 0; t -= 2) {
+				const auto& k = k_history[t];
+				if (k.first == hash && k.second == player.kyokumen.getBammen()) {
+					repnum++;
+					repnode = history[t];
+					if (latestRepnode == nullptr) {
+						latestRepnode = repnode;
+					}
+				}
+			}
+			if (latestRepnode == nullptr) {
+				latestRepnode = repnode;
+			}
+		}
+		if (repnum > 0/*千日手である*/) {
+			if (checkRepetitiveCheck(player.kyokumen, history, latestRepnode)) {
+				node->setRepetitiveCheckmate();
+			}
+			else {
+				node->setRepetition(player.kyokumen.teban());
+			}
+			goto backup;
+		}
+		{//子ノード生成
+			const auto moves = MoveGenerator::genMove(node->move, player.kyokumen);
+			if (moves.empty()) {
+				node->setMate();
+				goto backup;
+			}
+			else if (history.size() - 1 + tree->getMoveNum() >= drawmovenum) {
+				node->setRepetition(player.kyokumen.teban());
+				goto backup;
+			}
+			node->addChildren(moves);
+		}
+		uint64_t evalcount = 0ull;
+		for (auto& child : node->children) {
+			const auto cache = player.proceedC(child.move);
+			evalcount += qsimulate(&child, player, history.size());
+			player.recede(child.move, cache);
+		}
+		tree->addEvaluationCount(evalcount);
+		//sortは静止探索後の方が評価値順の並びが維持されやすい　親スタートの静止探索ならその前後共にsortしてもいいかもしれない
+		node->children.sort();
+		//sortしたので一番上が最小値になっているはず
+		double emin = node->children.begin()->eval;
+		double Z_e = 0;
+		for (const auto& child : node->children) {
+			Z_e += std::exp(-(child.eval - emin) / T_e);
+		}
+		double E = 0;
+		for (const auto& child : node->children) {
+			E -= child.eval * std::exp(-(child.eval - emin) / T_e) / Z_e;
+		}
+		node->setEvaluation(E);
+		node->setMass(1);
+		//node->status = SearchNode::State::E;
+	}//展開評価ここまで
+
+	//バックアップ
+backup:
+	{
+		for (int i = history.size() - 2; i >= 0; i--) {
+			node = history[i];
+			double emin = std::numeric_limits<double>::max();
+			std::vector<dd> emvec; emvec.reserve(node->children.size());
+			for (const auto& child : node->children) {
+				const double eval = child.getEvaluation();
+				const double mass = child.mass;
+				emvec.push_back(std::make_pair(eval, mass));
+				if (eval < emin) {
+					emin = eval;
+				}
+			}
+			if (std::abs(emin) > MateScoreBound) {
+				node->setMateVariation(emin);
+			}
+			else {
+				double Z_e = 0;
+				double Z_d = 0;
+				for (const auto& em : emvec) {
+					const double eval = em.first;
+					Z_e += std::exp(-(eval - emin) / T_e);
+					Z_d += std::exp(-(eval - emin) / T_d);
+				}
+				double E = 0;
+				double M = 1;
+				for (const auto& em : emvec) {
+					const double eval = em.first;
+					const double mass = em.second;
+					E -= eval * std::exp(-(eval - emin) / T_e) / Z_e;
+					M += mass * std::exp(-(eval - emin) / T_d) / Z_d;
+				}
+				node->setEvaluation(E);
+				node->setMass(M);
+			}
+		}
+	}
+}
+
+
+double _alphabeta(Move& pmove, SearchPlayer& player, int depth, double alpha, double beta, uint64_t& evalcount) {
+	evalcount++;
+	const auto eval = Evaluator::evaluate(player);
+	if (depth <= 0) {
+		return eval;
+	}
+	alpha = std::max(eval, alpha);
+	if (alpha >= beta) {
+		return alpha;
+	}
+	auto moves = MoveGenerator::genCapMove(pmove, player.kyokumen);
+	if (moves.empty() || pmove.isOute()) {
+		return eval;
+	}
+	for (auto& m : moves) {
+		const FeatureCache cache = player.feature.getCache();
+		const koma::Koma captured = player.proceed(m);
+		alpha = std::max(-_alphabeta(m, player, depth - 1, -beta, -alpha, evalcount), alpha);
+		player.recede(m, captured, cache);
+		if (alpha >= beta) {
+			return alpha;
+		}
+	}
+	return alpha;
+}
+
+size_t LearnAgent::qsimulate(SearchNode* const root, SearchPlayer& player, const int hislength) {
+	const int depth = SearchNode::getQSdepth();
+	if (depth <= 0) {
+		const double eval = Evaluator::evaluate(player);
+		root->setEvaluation(eval);
+		root->setOriginEval(eval);
+		return 1ull;
+	}
+	auto moves = MoveGenerator::genCapMove(root->move, player.kyokumen);
+	if (moves.empty()) {
+		if (root->move.isOute()) {
+			root->setMate();
+			return 1ull;
+		}
+		else {
+			const double eval = Evaluator::evaluate(player);
+			root->setEvaluation(eval);
+			root->setOriginEval(eval);
+			return 1ull;
+		}
+	}
+	else if (hislength - 1 + tree->getMoveNum() >= drawmovenum) {
+		root->setRepetition(player.kyokumen.teban());
+		return 1ull;
+	}
+	double max = Evaluator::evaluate(player);
+	uint64_t evaluationcount = 1ull;
+	for (auto& m : moves) {
+		const FeatureCache cache = player.feature.getCache();
+		const koma::Koma captured = player.proceed(m);
+		const double eval = -_alphabeta(m, player, depth - 1, std::numeric_limits<double>::lowest(), -max, evaluationcount);
+		if (eval > max) {
+			max = eval;
+		}
+		player.recede(m, captured, cache);
+	}
+	root->setEvaluation(max);
+	root->setOriginEval(max);
+	return evaluationcount;
+}
+
+
+bool LearnAgent::checkRepetitiveCheck(const Kyokumen& kyokumen, const std::vector<SearchNode*>& searchhis, const SearchNode* const repnode)const {
+	//対象ノードは未展開なので局面から王手かどうか判断する この関数は4回目の繰り返しの終端ノードで呼ばれているのでkusemonoを何回も生成するような無駄は発生していない
+	if (kyokumen.teban()) {
+		if (kyokumen.getSenteOuCheck().empty()) {
+			return false;
+		}
+	}
+	else {
+		if (kyokumen.getGoteOuCheck().empty()) {
+			return false;
+		}
+	}
+	searchhis.back()->move.setOute(true);
+	//過去ノードはmoveのouteフラグから王手だったか判定する
+	int t;
+	for (t = searchhis.size() - 3; t >= 0; t -= 2) {//historyの後端は末端ノードなのでその二つ前から調べていく
+		if (!searchhis[t]->move.isOute()) {
+			return false;
+		}
+		if (searchhis[t] == repnode) {
+			return true;
+		}
+	}
+	const auto& treehis = tree->getHistory();
+	for (t += treehis.size() - 1; t >= 0; t -= 2) {
+		if (!treehis[t]->move.isOute()) {
+			return false;
+		}
+		if (treehis[t] == repnode) {
+			return true;
+		}
+	}
+	return false;
+}
+
+
+void LearnAgent::del() {
+	const auto result = tree->deleteGarbage();
+	if (!result) status = State::pause;
+}
+
+void LearnAgentPool::deleteTree(SearchTree& tree) {
+	for (int i = 0; i < agentNum; i++) {
+		agents[i]->deleteTree();
+	}
+	for (int i = 0; i < agentNum; i++) {
+		agents[i]->join();
+	}
+}
+
+void LearnAgentPool::search(SearchTree& tree, std::chrono::milliseconds ms) {
+	if (agents.size() < agentNum) {
+		std::random_device rd;
+		Random::xoshiro256p random(rd(), rd(), rd(), rd());
+		for (int i = agents.size(); i < agentNum; i++) {
+			agents.emplace_back(new LearnAgent(random));
+			random.jump();
+		}
+	}
+	for (int i = 0; i < agentNum; i++) {
+		agents[i]->setTree(&tree);
+		agents[i]->start();
+	}
+	std::this_thread::sleep_for(ms);
+	for (int i = 0; i < agentNum; i++) {
+		agents[i]->stop();
+	}
+	for (int i = 0; i < agentNum; i++) {
+		agents[i]->join();
+	}
+}

--- a/FiveSquareShogi/learn_agent.h
+++ b/FiveSquareShogi/learn_agent.h
@@ -1,0 +1,58 @@
+﻿#pragma once
+#include "tree.h"
+#include "learn_method.h"
+#include "random.h"
+#include <condition_variable>
+#include <chrono>
+
+using Method = SamplingBTS;
+
+
+class LearnAgent {
+public:
+	static int drawmovenum;
+public:
+	LearnAgent(const Random::xoshiro256p&);
+
+	void setTree(SearchTree* const tree) { this->tree = tree; }
+	void setTs(const double T) { Ts = T; }
+	void start();
+	void stop();
+	void deleteTree();
+	void join();
+
+private:
+	enum class State {
+		pause, search, del, terminate
+	};
+	
+	void loop();
+	void search();
+	size_t qsimulate(SearchNode* const root, SearchPlayer& player, const int hislength);
+	bool checkRepetitiveCheck(const Kyokumen& k, const std::vector<SearchNode*>& searchhis, const SearchNode* const latestRepnode)const;
+	void del();
+
+	std::atomic<State> status;
+	std::atomic_bool inSearch;
+	std::mutex mtx;
+	std::condition_variable cv;
+	SearchTree* tree;
+	double Ts = 90;
+	std::thread th;
+	Random::xoshiro256p random;
+};
+
+class LearnAgentPool {
+public:
+	void setAgentNum(int num) { agentNum = num; }
+
+	void deleteTree(SearchTree& tree);
+	void search(SearchTree& tree, std::chrono::milliseconds ms);
+	//void search(SearchTree& tree, unsigned long long num);
+	//void learn(SearchTree& tree, Method& method);
+	
+private:
+	int agentNum = 8;
+	std::vector<std::unique_ptr<LearnAgent>> agents;
+
+};

--- a/FiveSquareShogi/learn_commander.cpp
+++ b/FiveSquareShogi/learn_commander.cpp
@@ -1,0 +1,606 @@
+﻿#include "learn_commander.h"
+#include "usi.h"
+#include <iostream>
+#include <fstream>
+#include <filesystem>
+
+void LearnCommander::execute() {
+	LearnCommander commander;
+	while (!commander.quit) {
+		std::string usiin;
+		std::getline(std::cin, usiin);
+		auto tokens = usi::split(usiin, ' ');
+		if (tokens.empty()) {
+			std::cout << "command ready" << std::endl;
+		}
+		else if (tokens[0] == "usi") {
+			coutID();
+			coutOption();
+			coutLearnerOption();
+			std::cout << "usiok" << std::endl;
+		}
+		else if (tokens[0] == "setoption") {
+			commander.setOption(tokens);
+			commander.setLearnerOption(tokens);
+		}
+		else if (tokens[0] == "isready") {
+			commander.gameInit();
+			std::cout << "readyok" << std::endl;
+		}
+		else if (tokens[0] == "usinewgame") {
+			commander.go_alive = false;
+		}
+		else if (tokens[0] == "position") {
+			commander.go_alive = false;
+			commander.info_enable = false;
+			commander.position(tokens);
+		}
+		else if (tokens[0] == "go") {
+			if (tokens[1] == "mate") {
+				//詰将棋は非対応
+				std::cout << "checkmate notimplemented" << std::endl;
+				continue;
+			}
+			commander.go(tokens);
+		}
+		else if (tokens[0] == "stop") {
+			commander.chakushu(commander.tree.getBestMove());
+		}
+		else if (tokens[0] == "fouttree") {
+			commander.tree.foutTree();
+			std::cout << "fouttree: done" << std::endl;
+		}
+		else if (tokens[0] == "ponderhit") {
+			//先読みはするがponder機能は利用しない
+		}
+		else if (tokens[0] == "gameover") {
+			commander.gameover(tokens);
+		}
+		else if (tokens[0] == "saveparam") {
+			//更新したパラメータを保存
+			//saveparam [保存先フォルダ]
+			if (tokens.size() >= 2) Evaluator::save(usiin.substr(10));
+			else Evaluator::save();
+			std::cout << "saveparam done." << std::endl;
+		}
+		else if (tokens[0] == "genparam") {
+			//学習前の初期パラメータを生成する
+			//genparam 出力先フォルダ
+			Evaluator::genFirstEvalFile(usiin.substr(9));
+		}
+		else if (tokens[0] == "debugsetup") {
+			auto setLeaveNodeCommand = usi::split("setoption name leave_branchNode value true", ' ');
+			commander.setOption(setLeaveNodeCommand);
+			commander.gameInit();
+			std::cout << "readyok" << std::endl;
+		}
+		else if (tokens[0] == "staticevaluate") {
+			std::cout << "info cp " << Evaluator::evaluate(commander.tree.getRootPlayer()) << std::endl;
+		}
+		else if (tokens[0] == "getsfen") {
+			std::cout << commander.tree.getRootPlayer().kyokumen.toSfen() << std::endl;
+		}
+		else if (tokens[0] == "showBanFigure") {
+			std::cout << commander.tree.getRootPlayer().kyokumen.toBanFigure() << std::endl;
+		}
+		else if (tokens[0] == "quit") {
+			return;
+		}
+	}
+}
+
+void LearnCommander::coutID() {
+	std::cout << "id name ";
+#ifdef LEARN_TD_LAMBDA_PROB
+	std::cout << "TD(l)prob_";
+#endif
+#ifdef LEARN_TD_LAMBDA_CP
+	std::cout << "TD(l)cp_";
+#endif
+#ifdef LEARN_PG
+	std::cout << "PG_";
+#endif
+#ifdef LEARN_REGRESSION
+	std::cout << "Reg_";
+#endif
+#ifdef LEARN_BOOTSTRAP_ROOT
+	std::cout << "BTSroot_";
+#endif
+#ifdef LEARN_BOOTSTRAP_RANDOM_NODE
+	std::cout << "BTSnode_";
+#endif
+#ifdef SAMPLING_GRAD_PROB
+	std::cout << "sampling(prob)_";
+#endif
+#ifdef SAMPLING_GRAD_CP
+	std::cout << "sampling(cp)_";
+#endif
+#ifdef PVLEAF_GRAD
+	std::cout << "pvleaf_";
+#endif
+	std::cout << "Learn" << std::endl;
+	std::cout << "id author Hiromasa_Iwamoto" << std::endl;
+}
+
+void LearnCommander::coutLearnerOption() {
+	using namespace std;
+	cout << "option name Batch_Num type spin default 1 min 1 max 99999999999" << endl;
+	cout << "option name T_search type string default 120" << endl;
+#ifdef SAMPLING_GRAD_PROB
+	cout << "option name Grad_Sampling_Num type spin default 10000 min 1 max 99999999999" << endl;
+	cout << "option name T_sampling_grad_prob type string default 1.0" << endl;
+#endif
+#ifdef LEARN_TD_LAMBDA
+	cout << "option name TD_lambda type string default 0.9" << endl;
+	cout << "option name TD_gamma type string default 0.95" << endl;
+	cout << "option name TD_rate type string default 0.1" << endl;
+#endif
+#ifdef LEARN_REGRESSION
+	cout << "option name Regression_rate type string default 200" << endl;
+#endif
+#ifdef LEARN_PG
+	cout << "option name PG_rate type string default 0.1" << endl;
+#endif
+#ifdef LEARN_BOOTSTRAP_ROOT
+	cout << "option name BTSroot_rate type string default 0.001" << endl;
+#endif
+#ifdef LEARN_BOOTSTRAP_RANDOM_NODE
+	cout << "option name BTSrandom_probability_rate type string default 0.01" << endl;
+	cout << "option name BTSrandom_rate type string default 0.0001" << endl;
+#endif
+	cout << "option name reward_win type string default 1" << endl;
+	cout << "option name reward_lose type string default -1" << endl;
+	cout << "option name reward_draw type string default 0" << endl;
+}
+
+void LearnCommander::setLearnerOption(const std::vector<std::string>& token) {
+	if (token[2] == "eval_folderpath") {
+		//継承元のオプションだが、学習するので出力先を設定している
+		const auto str = usi::combine(token.begin() + 4, token.end(), ' ');
+		Evaluator::setpath_output(token[4]);
+	}
+	else if (token[2] == "Batch_Num") {
+		batch = std::stoi(token[4]);
+	}
+	else if (token[2] == "T_search") {
+		T_search = std::stoull(token[4]);
+	}
+#ifdef SAMPLING_GRAD_PROB
+	else if (token[2] == "Grad_Sampling_Num") {
+		samplingnum = std::stoull(token[4]);
+	}
+	else if (token[2] == "T_sampling_grad_prob") {
+		T_sgp = std::stod(token[4]);
+	}
+#endif
+#ifdef LEARN_TD_LAMBDA
+	else if (token[2] == "TD_lambda") {
+		td_lambda = std::stod(token[4]);
+	}
+	else if (token[2] == "TD_gamma") {
+		td_gamma = std::stod(token[4]);
+	}
+	else if (token[2] == "TD_rate") {
+		td_rate = std::stod(token[4]);
+	}
+#endif
+#ifdef LEARN_REGRESSION
+	else if (token[2] == "Regression_rate") {
+		reg_rate = std::stod(token[4]);
+	}
+#endif
+#ifdef LEARN_PG
+	else if (token[2] == "PG_rate") {
+		pg_rate = std::stod(token[4]);
+	}
+#endif
+#ifdef LEARN_BOOTSTRAP_ROOT
+	else if (token[2] == "BTSroot_rate") {
+		btsroot_rate = std::stod(token[4]);
+	}
+#endif
+#ifdef LEARN_BOOTSTRAP_RANDOM_NODE
+	else if (token[2] == "BTSrandom_probability_rate") {
+		btsrand_exp = std::stod(token[4]);
+	}
+	else if (token[2] == "BTSrandom_rate") {
+		btsrand_rate = std::stod(token[4]);
+	}
+#endif
+	else if (token[2] == "reward_win") {
+		reward_win = std::stod(token[4]);
+	}
+	else if (token[2] == "reward_lose") {
+		reward_lose = std::stod(token[4]);
+	}
+	else if (token[2] == "reward_draw") {
+		reward_draw = std::stod(token[4]);
+	}
+}
+
+void LearnCommander::gameInit() {
+	BBkiki::init();
+	Evaluator::init();
+	SearchTemperature::Ts_max = T_search;
+	SearchTemperature::Ts_min = T_search;
+	SearchTemperature::TsDistFuncCode = 0;
+	SearchTemperature::TsNodeFuncCode = 0;
+	agents.setup();
+}
+
+bool LearnCommander::loadTempInfo(int& learncount, std::string& datestr, const std::string& dir) {
+	std::ifstream fs(dir + "/.cmlearninfo");
+	if (fs) {
+		std::getline(fs, datestr);
+		
+		std::string buff;
+
+		std::getline(fs, buff);
+		learncount = std::stoi(buff);
+		
+		return true;
+	}
+	else {
+		return false;
+	}
+}
+
+bool LearnCommander::saveTempInfo(const int& learncount, const std::string& datestr, const std::string& dir) {
+	std::filesystem::create_directories(dir);
+	std::ofstream fs(dir + "/.learninfo");
+	if (fs.is_open()) {
+		fs << datestr << "\n";
+		fs << learncount << "\n";
+		return true;
+	}
+	else {
+		return false;
+	}
+}
+
+bool LearnCommander::LoadTempVec(LearnVec& vec, const int vecnum, const std::string& dir) {
+	const std::string filepath = dir + "/.learngrad" + std::to_string(vecnum);
+	if (!std::filesystem::exists(filepath)) return false;
+	vec.load(filepath);
+	return true;
+}
+
+bool LearnCommander::SaveTempVec(LearnVec& vec, const int vecnum, const std::string& dir) {
+	std::filesystem::create_directories(dir);
+	vec.save(dir + "/.learngrad" + std::to_string(vecnum));
+	return true;
+}
+
+void LearnCommander::go(const std::vector<std::string>& tokens) {
+	const Kyokumen& kyokumen = tree.getRootPlayer().kyokumen;
+	tree.evaluationcount = 0;
+	agents.startSearch();
+	TimeProperty tp(kyokumen.teban(), tokens);
+	go_alive = false;
+	if (go_thread.joinable()) go_thread.join();
+	go_alive = true;
+	if (tp.rule == TimeProperty::TimeRule::infinite) return;
+
+	go_thread = std::thread([this, tp]() {
+		using namespace std::chrono_literals;
+		const auto starttime = std::chrono::system_clock::now();
+		const SearchNode* root = tree.getRoot();
+		const auto timelimit = decide_timelimit(tp);
+		auto searchtime = timelimit.first;//探索時間
+		SearchNode* provisonalBestMove = nullptr;//暫定着手
+
+		double provisonal_pi = 0;//暫定着手の方策
+		SearchNode* recentBestNode = nullptr;//直前の最善ノード
+		double pi_average = 0;//最善手の方策の時間平均
+		int continuous_counter = 0;//最善手が同じまま連続している回数
+		int changecounter = 0;
+		int loopcounter = 0;
+		std::cout << "info string time:" << timelimit.first.count() << ", " << timelimit.second.count() << std::endl;
+		std::this_thread::sleep_for(1ms);
+		
+		if (tp.rule == TimeProperty::TimeRule::fischer || tp.left > 100ms) {
+			do {
+				loopcounter++;
+				constexpr auto sleeptime = 50ms;
+				std::this_thread::sleep_for(sleeptime);
+				const auto bestnode = root->getBestChild();
+				const double pi = root->getChildRate(bestnode, 40);
+				if (bestnode == recentBestNode) { //最善ノードが変わっていない
+					pi_average = (pi_average * continuous_counter + pi) / ((double)continuous_counter + 1);
+					continuous_counter++;
+					if (continuous_counter > 4) { //一定回数以上最善が不変であれば信頼できるとして暫定着手とする
+						provisonalBestMove = recentBestNode;
+						provisonal_pi = pi_average;
+					}
+				}
+				else {
+					changecounter++;
+					pi_average = pi;
+					continuous_counter = 1;
+				}
+				recentBestNode = bestnode;
+				//即指しの条件を満たしたら指す
+				if (continuous_counter * sleeptime > std::max(timelimit.first / 2, time_quickbm_lower)) {
+					break;
+				}
+				if ((loopcounter & 0xF) == 0) {
+					double changerate = (double)changecounter / loopcounter;
+					searchtime = (changerate > 0.05) ? std::chrono::duration_cast<std::chrono::milliseconds>(timelimit.first * changerate / 0.05) : timelimit.first;
+				}
+				//標準時間になったら指すか決める もし拮抗している局面なら時間を延長する
+				if (std::chrono::system_clock::now() - starttime >= searchtime && provisonalBestMove != nullptr) {
+					break;
+				}
+				//時間上限になったら指す
+				if (std::chrono::system_clock::now() - starttime + sleeptime >= timelimit.second) {
+					break;
+				}
+			} while (std::abs(root->eval) < SearchNode::getMateScoreBound());
+			agents.pauseSearch();
+			agents.joinPause();
+		}
+		else {
+			std::this_thread::sleep_for(tp.added);
+			agents.pauseSearch();
+			agents.joinPause();
+			const auto bestnode = root->getBestChild();
+			provisonalBestMove = bestnode;
+			recentBestNode = bestnode;
+		}
+		
+		if (provisonalBestMove == nullptr) provisonalBestMove = recentBestNode;
+
+		learn_from_tree(tree.getRootPlayer(), root, provisonalBestMove);
+		chakushu(provisonalBestMove);
+	});
+}
+
+void LearnCommander::gameover(const std::vector<std::string>& tokens) {
+	go_alive = false;
+	info_alive = false;
+	quit = true;
+	agents.pauseSearch();
+
+	if (tokens.size() >= 2 && !learned_gameover) {
+		if (tokens[1] == "win") learn_at_gameover(MyGameResult::PlayerWin);
+		else if (tokens[1] == "lose") learn_at_gameover(MyGameResult::PlayerLose);
+		else if (tokens[1] == "draw") learn_at_gameover(MyGameResult::Draw);
+	}
+}
+
+void LearnCommander::learn_from_tree(const SearchPlayer& kyokumen, const SearchNode* const root, const SearchNode* const bestmove) {
+	if (root == nullptr) return;
+
+	if (learned_gameover) { return; }
+	if (std::abs(root->eval) >= SearchNode::getMateScoreBound()) {
+		//詰んでいたら学習終了
+		learned_gameover = true;
+		if (root->eval > 0) {
+			learn_at_gameover(MyGameResult::PlayerWin);
+		}
+		else {
+			learn_at_gameover(MyGameResult::PlayerLose);
+		}
+		return;
+	}
+
+	LearnVec dv;
+	double eval = 0;
+#ifdef LEARN_PG
+	LearnVec pg_dQt, pg_dPQ;
+	long long pg_Qtcount = 0;
+#endif
+#ifdef LEARN_BOOTSTRAP_RANDOM_NODE
+#define Learn_BTS_random(vec, H, V, player) {if(btsrand_exp < random.rand01()) vec.addGrad(LearnUtil::EvalToProb(H) - LearnUtil::EvalToProb(V), player); }
+#else
+#define	Learn_BTS_random(dw, c, player) ((void)0)
+#endif
+#ifdef PVLEAF_GRAD
+#ifdef LEARN_V
+	{
+		const SearchNode* node = root;
+		SearchPlayer player = kyokumen;
+		int depth = 0;
+		while (!node->isLeaf()) {
+			//二手ずつ進める (相手番が末端になっていればその手前で終了)
+			const SearchNode* const child = LearnUtil::choiceBestChild(node);
+			if (child == nullptr || child->isLeaf()) break;
+			const SearchNode* next = LearnUtil::choiceBestChild(child);
+			if (next == nullptr) break;
+			player.proceed(child->move);
+			Learn_BTS_random(dw_btsrand, Evaluator::evaluate(player), child->eval, player);
+			player.proceed(next->move);
+			Learn_BTS_random(dw_btsrand, Evaluator::evaluate(player), next->eval, player);
+			node = next;
+			depth++;
+		}
+#ifdef LEARN_QS_LEAF
+		player = LearnUtil::getQSBest(node, player);
+#endif
+		dv.addGrad(1, player);
+		eval = Evaluator::evaluate(player);
+		//std::cout << "(d:" << depth << ") ";
+	}
+#endif //LEARN_V
+#ifdef LEARN_PG
+	if (!root->children.empty() && !root->isLeaf()) {//PG-Leaf
+		double Z, e_min;
+		Z = LearnUtil::getChildrenZ(root, T_pg, e_min);
+		if (Z != 0) {
+			for (const auto& a : root->children) {
+				if (a.isLeaf() || a.children.empty()) continue;
+				SearchPlayer player = kyokumen;
+				//一手進めて自手番にする(一手も進まない場合はスキップしている)
+				const SearchNode* node = LearnUtil::choiceBestChild(&a);
+				if (node == nullptr) continue;
+				player.proceed(a.move);
+				Learn_BTS_random(dw_btsrand, Evaluator::evaluate(player), a.eval, player);
+				player.proceed(node->move);
+				while (!node->isLeaf()) {
+					//二手ずつ進める (相手番が末端になっていればその手前で終了)
+					const SearchNode* const child = LearnUtil::choiceBestChild(node);
+					if (child == nullptr || child->isLeaf()) break;
+					const SearchNode* next = LearnUtil::choiceBestChild(child);
+					if (next == nullptr) break;
+					Learn_BTS_random(dw_btsrand, Evaluator::evaluate(player), node->eval, player);
+					player.proceed(child->move);
+					Learn_BTS_random(dw_btsrand, Evaluator::evaluate(player), child->eval, player);
+					player.proceed(next->move);
+					node = next;
+				}
+#ifdef LEARN_QS_LEAF
+				player = LearnUtil::getQSBest(node, player);
+#endif
+				const double p = std::exp(-(a.eval - e_min) / T_pg) / Z;
+				if (a.move == bestmove->move) {
+					pg_e_vec.addGrad(1.0 - p, player);
+				}
+				else {
+					pg_e_vec.addGrad(-p, player);
+				}
+			}
+		}
+	}
+#endif //LEARN_PG
+#endif //PVLEAF_GRAD
+
+#ifdef SAMPLING_GRAD
+	eval = root->eval;
+	if(!root->isLeaf()){
+		const double T = SearchTemperature::Te;
+		for (int _sample = 0; _sample < samplingnum; _sample++) {
+			SearchPlayer player = kyokumen;
+			double c = 1;
+			//始めの2手を計算
+			const double V0 = root->eval;
+			const SearchNode* const a = LearnUtil::choicePolicyRandomChild(root, T, random.rand01());
+			if (a != nullptr && !a->children.empty() && !a->isLeaf()) {
+				const double Q0 = -a->eval;
+				const SearchNode* node = LearnUtil::choicePolicyRandomChild(a, T, random.rand01());
+				if (node != nullptr) {
+					player.proceed(a->move);
+					Learn_BTS_random(dw_btsrand, Evaluator::evaluate(player), a->eval, player);
+					player.proceed(node->move);
+					//末端まで移動
+					while (!node->isLeaf() && !node->children.empty()) {
+						const auto child = LearnUtil::choicePolicyRandomChild(node, T, random.rand01());
+						if (child == nullptr || child->isLeaf() || child->children.empty()) break;
+						const auto next = LearnUtil::choicePolicyRandomChild(child, T, random.rand01());
+						if (next == nullptr) break;
+
+						const double V = node->eval;
+						const double Q = -child->eval;
+#ifdef SAMPLING_GRAD_CP
+						c *= (Q - V) / T + 1.0;
+#elif defined(SAMPLING_GRAD_PROB)
+						c *= (LearnUtil::EvalToProb(Q) - LearnUtil::EvalToProb(V)) / T_sgp + 1.0;
+#endif
+						Learn_BTS_random(dw_btsrand, Evaluator::evaluate(player), node->eval, player);
+						player.proceed(child->move);
+						Learn_BTS_random(dw_btsrand, Evaluator::evaluate(player), child->eval, player);
+						player.proceed(next->move);
+
+						node = next;
+					}
+#ifdef LEARN_PG
+					pg_dPQ.addGrad(c, player);
+					if (a->move == bestmove->move) { 
+						pg_dQt.addGrad(c, player); 
+						pg_Qtcount++;
+					}
+#endif
+#ifdef SAMPLING_GRAD_CP
+					c *= (Q0 - V0) / T + 1.0; //根直下の係数の計算を最後にすることでPGLeafの計算も一緒にできる
+#elif defined(SAMPLING_GRAD_PROB)
+					c *= (LearnUtil::EvalToProb(Q0) - LearnUtil::EvalToProb(V0)) / T_sgp + 1.0;
+#endif
+				
+				}
+			}
+			dv.addGrad(c, player);
+		}
+		dv *= (1.0 / samplingnum);
+	}
+	else {
+		dv.addGrad(1, kyokumen);
+	}
+#endif
+	
+#ifdef LEARN_TD_LAMBDA
+	{
+#ifdef LEARN_TD_LAMBDA_CP
+		const double td_eval = eval;
+#elif defined(LEARN_TD_LAMBDA_PROB)
+		const double td_eval = LearnUtil::EvalToProb(eval);
+#endif
+		if (!td_first) {
+			const double delta = td_gamma * td_eval - td_Vt;
+			dw_td += delta * td_e_vec;
+		}
+		else {
+			td_first = false;
+		}
+		td_Vt = td_eval;
+		td_e_vec *= td_gamma * td_lambda;
+		td_e_vec += dv;
+	}
+#endif
+#ifdef LEARN_REGRESSION
+	{
+		const double Pwin = LearnUtil::EvalToProb(eval);
+		dw_reg_win += (1.0 - Pwin) * (1 / LearnUtil::probT) * (1 - Pwin) * Pwin * dv;
+		dw_reg_lose += (0 - Pwin) * (1 / LearnUtil::probT) * (1 - Pwin) * Pwin * dv;
+	}
+#endif
+#ifdef LEARN_PG
+	pg_dQt *= 1.0 / pg_Qtcount;
+	pg_dPQ *= -1.0 / samplingnum;
+	pg_dQt += pg_dPQ;
+	dw_pg += pg_dQt;
+#endif
+#ifdef LEARN_BOOTSTRAP_ROOT
+	{
+		const double H = Evaluator::evaluate(kyokumen);
+		dw_btsroot += (LearnUtil::EvalToProb(H) - LearnUtil::EvalToProb(eval)) * dv;
+	}
+#endif
+#undef Learn_BTS_random
+}
+
+void LearnCommander::learn_at_gameover(MyGameResult result) {
+	LearnVec dw;
+	const std::string vec_tempfilepath = Evaluator::getpath_output() + "/.learngrad";
+	if(std::filesystem::exists(vec_tempfilepath)) dw.load(vec_tempfilepath);
+#ifdef LEARN_TD_LAMBDA
+	{
+		const double r = LearnUtil::ResultToReward(result, reward_win, reward_draw, reward_lose);
+		const double delta = r + td_gamma * td_Vt - td_Vt;
+		dw_td += delta * td_e_vec;
+		dw += td_rate * dw_td;
+	}
+#endif
+#ifdef LEARN_REGRESSION
+	if (result == MyGameResult::PlayerWin) {
+		dw += reg_rate * dw_reg_win;
+	}
+	else if (result == MyGameResult::PlayerLose) {
+		dw += reg_rate * dw_reg_lose;
+	}
+#endif
+#ifdef LEARN_PG
+	{
+		const double r = LearnUtil::ResultToReward(result, reward_win, reward_draw, reward_lose);
+		dw += pg_rate * r * dw_pg;
+	}
+#endif
+#ifdef LEARN_BOOTSTRAP_ROOT
+	dw += -btsroot_rate * dw_btsroot;
+#endif
+#ifdef LEARN_BOOTSTRAP_RANDOM_NODE
+	dw += -btsrand_rate * dw_btsrand;
+#endif
+	dw.updateEval();//評価値に反映
+	Evaluator::save();//保存
+	dw.save(vec_tempfilepath);
+	std::cout << "info string learn end." << std::endl;
+}

--- a/FiveSquareShogi/learn_commander.h
+++ b/FiveSquareShogi/learn_commander.h
@@ -1,0 +1,98 @@
+﻿#pragma once
+#include "commander.h"
+#include "learn_util.h"
+
+#define SAMPLING_GRAD_PROB //サンプリングによる勾配ベクトル
+//#define SAMPLING_GRAD_CP
+//#define PVLEAF_GRAD //最善応手手順の末端ノードによる勾配ベクトル
+
+#define LEARN_TREE_LEAF //末端ノードの局面で学習
+//#define LEARN_QS_LEAF //末端ノードから静止探索した局面で学習
+
+#define LEARN_TD_LAMBDA_CP
+//#define LEARN_TD_LAMBDA_PROB
+#define LEARN_PG
+#define LEARN_REGRESSION
+//#define LEARN_BOOTSTRAP_ROOT
+#define LEARN_BOOTSTRAP_RANDOM_NODE
+
+#if defined(SAMPLING_GRAD_PROB) || defined(SAMPLING_GRAD_CP)
+#define SAMPLING_GRAD
+#endif
+
+#if defined(LEARN_TD_LAMBDA_PROB) || defined(LEARN_TD_LAMBDA_CP)
+#define LEARN_TD_LAMBDA
+#endif
+#if defined(LEARN_TD_LAMBDA) || defined(LEARN_REGRESSION)
+#define LEARN_V
+#endif
+
+class LearnCommander : Commander {
+	
+public:
+	static void execute();
+
+protected:
+	static void coutID();
+	static void coutLearnerOption();
+	void setLearnerOption(const std::vector<std::string>& token);
+	void gameInit();
+
+	static bool loadTempInfo(int& learncount, std::string& datestr, const std::string& dir = "./learning/");
+	static bool saveTempInfo(const int& learncount, const std::string& datestr, const std::string& dir = "./learning/");
+	static bool LoadTempVec(LearnVec& vec, const int vecnum = 1, const std::string& dir = "./learning/");
+	static bool SaveTempVec(LearnVec& vec, const int vecnum = 1, const std::string& dir = "./learning/");
+
+	void go(const std::vector<std::string>& tokens);
+	void gameover(const std::vector<std::string>& tokens);
+	
+	void learn_from_tree(const SearchPlayer& kyokumen, const SearchNode* const root, const SearchNode* const bestmove);
+	void learn_at_gameover(MyGameResult result);
+
+	bool quit = false;
+	Random::xoshiro256p random;
+
+	int batch = 1;
+	double T_search = 120;
+
+	bool learned_gameover = false;
+
+#ifdef SAMPLING_GRAD
+	long long unsigned samplingnum = 10000;
+	double T_sgp = 1.0;
+#endif
+
+#ifdef LEARN_TD_LAMBDA
+	double td_rate = 0.01;
+	double td_lambda = 0.9;
+	double td_gamma = 0.95;
+	
+	LearnVec dw_td, td_e_vec;
+	double td_Vt = 0.5;
+	bool td_first = true;
+#endif
+
+#ifdef LEARN_REGRESSION
+	double reg_rate = 0.01;
+	LearnVec dw_reg_win, dw_reg_lose;
+#endif
+
+#ifdef LEARN_PG
+	double pg_rate = 0.01;
+	LearnVec dw_pg;
+#endif
+
+#ifdef LEARN_BOOTSTRAP_ROOT
+	double btsroot_rate = 0.001;
+	LearnVec dw_btsroot;
+#endif
+#ifdef LEARN_BOOTSTRAP_RANDOM_NODE
+	double btsrand_rate = 0.01;
+	double btsrand_exp = 0.0001;
+	LearnVec dw_btsrand;
+#endif
+
+	double reward_win = 1.0;
+	double reward_lose = -1.0;
+	double reward_draw = 0;
+};

--- a/FiveSquareShogi/learn_method.cpp
+++ b/FiveSquareShogi/learn_method.cpp
@@ -79,7 +79,7 @@ void SamplingPGLeaf::update(SearchNode* const root, const SearchPlayer& rootplay
 	for (const auto& child : root->children) {
 		visited.clear();
 		const double pi = std::exp(-(child.eval - cmin) / T) / Z;
-		std::cout << pi << "\n";
+		//std::cout << pi << "\n";
 		const std::size_t p_sanpling_num = pi * sampling_num;
 		if (p_sanpling_num == 0)continue;
 		std::vector<Move> check1;

--- a/FiveSquareShogi/learn_util.h
+++ b/FiveSquareShogi/learn_util.h
@@ -5,29 +5,44 @@
 
 #ifdef USE_KPPT
 using LearnVec = kppt::kppt_paramVector;
+using LearnOpt = kppt::Adam;
 #endif
 
 #ifdef USE_KKPPT
 using LearnVec = kkppt::kkppt_paramVector;
 #endif
 
+enum class GameResult {
+	SenteWin, GoteWin, Draw
+};
+
+enum class MyGameResult {
+	PlayerWin, PlayerLose, Draw
+};
+
 class LearnUtil {
 public:
+	static double getChildrenZ(const SearchNode* const parent, const double T, double& CE);
 	static SearchNode* choicePolicyRandomChild(const SearchNode* const root, const double T, double pip);
 	static SearchNode* choiceRandomChild(const SearchNode* const root, double pip);
 	static SearchNode* choiceBestChild(const SearchNode* const root);
 	static SearchNode* getPrincipalLeaf(const SearchNode* const root);
 	static SearchPlayer getQSBest(const SearchNode* const root, SearchPlayer& player, const int depthlimit);
+	static SearchPlayer getQSBest(const SearchNode* const root, SearchPlayer& player);
 	static LearnVec getGrad(const SearchNode* const root, const SearchPlayer& player, bool teban, unsigned long long samplingnum, const int qsdepth=8);
 	static LearnVec getSamplingGrad(const SearchNode* root, const SearchPlayer& player, bool teban, unsigned long long samplingnum, const int qsdepth = 8);
 	static LearnVec getSamplingGradV(const SearchNode* root, const SearchPlayer& player,unsigned samplingnum);
 	static LearnVec getSamplingGradQ(const SearchNode* root, const SearchPlayer& player, unsigned samplingnum);
 	static double EvalToProb(const double eval);
 	static double BackProb(const SearchNode& parent, const SearchNode& child, const double T);
+	static double ResultToProb(GameResult result, bool teban);
+	static double ResultToReward(GameResult result, bool teban, double r_win, double r_draw, double r_lose);
+	static double ResultToProb(MyGameResult result);
+	static double ResultToReward(MyGameResult result, double r_win, double r_draw, double r_lose);
+	static std::string ResultToString(const GameResult& result);
+	static std::string ResultToString(const MyGameResult& result);
 	static constexpr double probT = 600.0;
 	static double pTb;
-};
-
-enum class GameResult {
-	SenteWin, GoteWin, Draw
+	static double change_evalTs_to_probTs(const double evalT);
+	static std::string getDateString();
 };

--- a/FiveSquareShogi/learner.cpp
+++ b/FiveSquareShogi/learner.cpp
@@ -4,16 +4,46 @@
 #include <filesystem>
 #include <ctime>
 #include "usi.h"
+#include "simulation.h"
+
+void Kifu::read_from_command() {
+	std::string line;
+	std::cout << "kifu sfen line > ";
+	std::getline(std::cin, line);
+	auto tokens = usi::split(line, ' ');
+	startpos = Kyokumen(tokens);
+	moves = Move::usiToMoves(tokens);
+	
+	teban:
+	std::cout << "learner teban (s/g) > ";
+	std::cin >> line;
+	if (line == "g") teban = false;
+	else if (line == "s") teban = true;
+	else goto teban;
+
+	winner:
+	std::cout << "game winner (s/g/d) > ";
+	std::cin >> line;
+	if (line == "d") result = GameResult::Draw;
+	else if (line == "g") result = GameResult::GoteWin;
+	else if (line == "s") result = GameResult::SenteWin;
+	else goto winner;
+}
 
 void Learner::execute() {
 	Learner learner;
-	LearnVec dw;
-	while (true) {
+	//LearnVec dw;
+	while (learner.enable) {
 		std::string usiin;
 		std::getline(std::cin, usiin);
 		auto tokens = usi::split(usiin, ' ');
 		if (tokens.empty()) {
 			std::cout << "command ready" << std::endl;
+		}
+		else if (tokens[0] == "usi") {
+			std::cout << "id name TD(l)_pvleaf_Learn" << std::endl;
+			coutOption();
+			std::cout << "usiok" << std::endl;
 		}
 		else if (tokens[0] == "setoption") {
 			if (tokens[1] == "evalinput") {
@@ -24,38 +54,51 @@ void Learner::execute() {
 				Evaluator::setpath_output(tokens[2]);
 				std::cout << "set evaloutput" << std::endl;
 			}
+			learner.setOption(tokens);
 		}
 		else if (tokens[0] == "init") {
 			//設定ファイルを読み込む
 			//init 設定ファイル.txt
 			learner.init(tokens);
-			std::cout << "init done." << std::endl;
+			std::cout << "readyok" << std::endl;
 		}
 		else if (tokens[0] == "genparam") {
 			//学習前の初期パラメータを生成する
 			//genparam 出力先フォルダ
 			Evaluator::genFirstEvalFile(usiin.substr(9));
 		}
+		else if (tokens[0] == "updateparam") {
+			//dw.updateEval();
+		}
 		else if (tokens[0] == "saveparam") {
 			//更新したパラメータを保存
 			//saveparam [保存先フォルダ]
-			if (tokens.size() > 2) Evaluator::setpath_input(usiin.substr(10));
-			dw.updateEval();
-			Evaluator::save();
+			if (tokens.size() >= 2) Evaluator::save(usiin.substr(10));
+			else Evaluator::save();
 			std::cout << "saveparam done." << std::endl;
 		}
 		else if (tokens[0] == "printparam") {
 			Evaluator::print((tokens.size() > 1) ? std::stoi(tokens[1]) : 0);
 		}
 		else if (tokens[0] == "loadgrad") {
-			dw.load(tokens.size() > 1 ? tokens[1] : "learninggrad.bin");
+			//dw.load(tokens.size() > 1 ? tokens[1] : "learninggrad.bin");
 		}
 		else if (tokens[0] == "savegrad") {
-			dw.save(tokens.size() > 1 ? tokens[1] : "learninggrad.bin");
+			//dw.save(tokens.size() > 1 ? tokens[1] : "learninggrad.bin");
 		}
 		else if (tokens[0] == "randomposlearn") {
 			if (tokens.size() < 2) { std::cout << "randomposlearn <batchsize> <itrsize>" << std::endl; continue; }
 			learner.learn_start_by_randompos(std::stoi(tokens[1]), std::stoi(tokens[2]));
+		}
+		else if (tokens[0] == "learnbykifu") {
+			if (tokens.size() >= 2 && tokens[1] == "options") {
+				learner.lbk_options();
+				continue;
+			}
+			learner.learn_by_kifu();
+		}
+		else if (tokens[0] == "test") {
+			learner.test();
 		}
 		else if (tokens[0] == "quit") {
 			break;
@@ -66,6 +109,87 @@ void Learner::execute() {
 void Learner::init(const std::vector<std::string>& cmdtokens) {
 	BBkiki::init();
 	Evaluator::init();
+	SearchTemperature::TsDistFuncCode = 0;
+	SearchTemperature::TsNodeFuncCode = 0;
+}
+
+void Learner::coutOption() {
+	using namespace std;
+	cout << "option name eval_folderpath type string default ./data/kppt" << endl;
+	cout << "option name use_dynamicPieceScore type check default false" << endl;
+	//cout << "option name NumOfAgent type spin default 12 min 1 max 128" << endl;
+	cout << "option name QSearch_depth type string default 8" << endl;
+	cout << "option name T_search type string default 180" << endl;
+	cout << "option name T_eval type string default 40" << endl;
+	cout << "option name T_depth type string default 100" << endl;
+	cout << "option name Es_functionCode type spin default 18 min 0 max 20" << endl;
+	cout << "option name Es_funcParam type string default 0.5" << endl;
+	//cout << "option name NodeMaxNum type string default 100000000" << endl;
+	cout << "option name DrawMoveNum type spin default 320 min 0 max 1000000" << endl;
+	
+	cout << "option name Sampling_Num type spin default 10000 min 1 max 99999999999" << endl;
+
+	cout << "option name TD_lambda type string default 0.9" << endl;
+	cout << "option name TD_gamma type string default 0.95" << endl;
+	cout << "option name TD_rate type string default 0.1" << endl;
+
+	cout << "option name Regression_rate type string default 0.1" << endl;
+}
+
+void Learner::setOption(const std::vector<std::string>& token) {
+	if (token.size() > 4) {
+		if (token[2] == "eval_folderpath") {
+			//aperyのパラメータファイルの位置を指定する 空白文字がパスにあると駄目なのを何とかしたい?
+			Evaluator::setpath_input(token[4]);
+			Evaluator::setpath_output(token[4]);
+		}
+#if defined(USE_KPPT) || defined(USE_KKPPT)
+		else if (token[2] == "use_dynamicPieceScore") {
+			Evaluator::use_dynamicPieceScore(token[4] == "true");
+		}
+#endif
+		else if (token[2] == "NumOfAgent") {
+			agents.setAgentNum(std::stoi(token[4]));
+		}
+		else if (token[2] == "QSearch_depth") {
+			SearchNode::setQSearchDepth(std::stod(token[4]));
+		}
+		else if (token[2] == "T_search") {
+			T_search = std::stod(token[4]);
+			SearchTemperature::Ts_max = std::stod(token[4]);
+			SearchTemperature::Ts_min = std::stod(token[4]);
+		}
+		else if (token[2] == "T_eval") {
+			SearchTemperature::Te = (std::stod(token[4]));
+		}
+		else if (token[2] == "T_depth") {
+			SearchTemperature::Td = (std::stod(token[4]));
+		}
+		else if (token[2] == "Es_functionCode") {
+			SearchNode::setEsFuncCode(std::stoi(token[4]));
+		}
+		else if (token[2] == "Es_funcParam") {
+			SearchNode::setEsFuncParam(std::stod(token[4]));
+		}
+		else if (token[2] == "DrawMoveNum") {
+			SearchAgent::setDrawMoveNum(std::stoi(token[4]));
+		}
+		else if (token[2] == "Sampling_Num") {
+			samplingnum = std::stoull(token[4]);
+		}
+		else if (token[2] == "TD_lambda") {
+			td_lambda = std::stod(token[4]);
+		}
+		else if (token[2] == "TD_gamma") {
+			td_gamma = std::stod(token[4]);
+		}
+		else if (token[2] == "TD_rate") {
+			learning_rate_td = std::stod(token[4]);
+		}
+		else if (token[2] == "Regression_rate") {
+			learning_rate_reg = std::stod(token[4]);
+		}
+	}
 }
 
 void Learner::search(SearchTree& tree) {
@@ -73,17 +197,15 @@ void Learner::search(SearchTree& tree) {
 }
 
 void Learner::search(SearchTree& tree, const std::chrono::milliseconds time) {
-	using namespace std::chrono_literals;
-	constexpr auto checkflame = 50ms;
-	AgentPool agents(tree);
 	agents.setAgentNum(agentnum);
-	const auto starttime = std::chrono::system_clock::now();
-	const SearchNode* const root = tree.getRoot();
-	while (std::abs(root->eval) < SearchNode::getMateScoreBound() && std::chrono::system_clock::now() - starttime < time) {
-		std::this_thread::sleep_for(checkflame);
+	agents.search(tree, time);
+}
+
+void Learner::search(SearchTree& tree, const long long simulate_num) {
+	for (int t = 0; t < simulate_num; t++) {
+		Simulation s(tree, T_search);
+		s.simulate();
 	}
-	agents.pauseSearch();
-	agents.terminate();
 }
 
 //どちらが勝ったかを返す関数 1:先手勝ち -1:後手勝ち 0:引き分け
@@ -102,28 +224,23 @@ int Learner::getWinner(std::vector<std::string>& sfen) {
 	else return 0;
 }
 
-const std::string getDateString() {
-	std::time_t now = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
-	std::string s(30, '\0');
-	std::tm ima;
-	localtime_s(&ima, &now);
-	std::strftime(&s[0], s.size(), "%Y%m%d-%H%M", &ima);
-	s.resize(s.find('\0'));
-	return s;
-}
+
 
 void Learner::learn_start_by_randompos(const int batch,const int itr) {
 	std::cout << "start randompos rootstarp learn\n";
 	std::uniform_real_distribution<double> random{ 0, 1.0 };
 	std::mt19937_64 engine{ std::random_device()() };
-	const std::string tempinfo = "./.learninfo";
-	const std::string tempgrad = "./.learngradient";
-	std::string datestring = getDateString();
+	const std::string tempinfo = "./learning/.learninfo";
+	const std::string tempgrad = "./learning/.learngrad";
+	const std::string learningdata_path = "./learning/";
+	std::filesystem::create_directories(learningdata_path);
+	std::string datestring = LearnUtil::getDateString();
 	int counter_itr = 0, counter_batch = 0;
 	unsigned long long rootnum = 0, learnedposnum = 0;
 	const double learn_rate_0 = 0.01;
 	const double learn_rate_r = 0.5;
 	LearnVec dw;
+	LearnOpt adam;
 	//保険セーブが残っているなら再開
 	{
 		std::ifstream fs(tempinfo);  
@@ -147,7 +264,7 @@ void Learner::learn_start_by_randompos(const int batch,const int itr) {
 	for (; counter_itr < itr; counter_itr++) {
 		for (; counter_batch < batch; counter_batch++) {
 			std::cout << "(" << counter_itr << "," << counter_batch << ")\n";
-			LearnMethod* method = new SamplingPGLeaf(dw, 0.001, 10000, 120);
+			LearnMethod* method = new SamplingPGLeaf(dw, 1, 10000, 120);
 			
 			tree.makeNewTree(usi::split("position startpos", ' '));
 			const int movesnum = 6 + 10 * random(engine);
@@ -206,11 +323,12 @@ void Learner::learn_start_by_randompos(const int batch,const int itr) {
 					fs << datestring << "\n" << counter_itr << "\n" << counter_batch << "\n" << rootnum << "\n" << learnedposnum << "\n";
 				}
 			}
+			agents.deleteTree(tree);
 			delete method;
 			std::cout << "\n";
 		}
 		//評価関数に勾配を反映
-		dw.updateEval();
+		adam.updateEval(dw);
 		Evaluator::save();
 		if ((((counter_itr + 1) % std::max(itr / 10, 1)) == 0)) {
 			const auto logpath = learnlogdir + "/" + std::to_string(counter_itr);
@@ -221,6 +339,7 @@ void Learner::learn_start_by_randompos(const int batch,const int itr) {
 				fs << rootnum << "\n" << learnedposnum << "\n";
 			}
 		}
+		adam.save(learningdata_path);
 		dw.save(tempgrad);
 		counter_batch = 0;
 	}
@@ -235,3 +354,350 @@ void Learner::learn_start_by_randompos(const int batch,const int itr) {
 	std::cout << "learning end." << std::endl;
 }
 
+void Learner::lbk_options() {
+	std::cout << "learning_name : TD_learn\n";
+	std::cout << "batch_size > 10\n";
+}
+
+//#define SAMPLING_GRAD
+#define PVLEAF_GRAD
+
+#define LEARN_TD_LAMBDA
+//#define LEARN_PG
+//#define LEARN_REGRESSION
+
+void Learner::learn_by_kifu() {
+	int itr = 0, batch = 0, itr_max = 1, bat_max = 1;
+	SearchTemperature::TsNodeFuncCode = 0;
+	const double T = SearchTemperature::Te;
+
+	LearnVec dw;
+	std::string datestr = LearnUtil::getDateString();
+	if (!LoadTempInfo(itr, batch, itr_max, bat_max, datestr)) {
+		std::cout << "new data\n";
+	}
+	else {
+		std::cout << "restart from temp data\n";
+		LoadTempVec(dw);
+	}
+	while (true) {
+		// 棋譜を読み込む
+		// 自分の手番と、勝ち負けを確認
+		Kifu kifu;
+		kifu.read_from_command();
+		std::cout << "learn start movenum? > \n";
+		long long startnum = 0;
+		std::cin >> startnum;
+		std::vector<Move> history;
+		// 学習の準備
+		SearchTree tree;
+		tree.makeNewTree(kifu.startpos, {});
+
+		std::cout << "learn start " << (kifu.teban ? "s " : "g ") << (kifu.result == GameResult::SenteWin ? "sw " : "gw ") << startnum << std::endl;
+
+#ifdef LEARN_TD_LAMBDA
+		//TD
+		double Vt_1 = 0.5; 
+		LearnVec e_vec, dw_td;
+		const double lambda = td_lambda, gamma = td_gamma, alpha = learning_rate_td;
+		bool td_first = true;
+#endif
+#ifdef LEARN_PG
+		LearnVec dw_pg;
+		const double pg_r = LearnUtil::ResultToReward(kifu.result, kifu.teban, pg_r_win, pg_r_draw, pg_r_lose);
+		const double pg_epsilon = learning_rate_pg;
+#endif
+#ifdef LEARN_REGRESSION
+		//回帰
+		LearnVec dw_reg;
+		const double reg_r = LearnUtil::ResultToProb(kifu.result, kifu.teban);
+		const double reg_epsilon = learning_rate_reg;
+#endif
+
+		//一手ずつ進めながら学習
+		for (int t = 0; t <= kifu.moves.size(); t++) {
+			
+			const auto& rootplayer = tree.getRootPlayer();
+			//自手番を学習
+			if (t >= startnum - 2 && rootplayer.kyokumen.teban() == kifu.teban) {
+				
+				//終局ならループ離脱
+				if (t >= kifu.moves.size() - 1) {
+					break;
+				}
+
+#ifndef SEARCH_WITH_SAMPLING
+				//探索
+				std::cout << "s";
+				search(tree, samplingnum);
+				std::cout << "(d:" << tree.getRoot()->mass.load() << ") ";
+
+				//詰みが発生しているならループ離脱
+				if (tree.getRoot()->isMate()) {
+					break;
+				}
+
+				//勾配ベクトル
+				std::cout << "l";
+				LearnVec dv;
+				double eval;
+#ifdef SAMPLING_GRAD
+#ifdef LEARN_PG
+				double pge_Z, pge_min_eval;
+				pge_Z = LearnUtil::getChildrenZ(tree.getRoot(), T, pge_min_eval);
+#endif
+				{	//サンプリングによる勾配
+					for (int _i = 0; _i < samplingnum; _i++) {
+						Simulation sim(tree, T);
+						sim.init();
+						double c = 1;
+#ifdef LEARN_PG
+						bool pge_first_child = true;
+						double pge_P = 0, pge_invc = 1;
+#endif
+						while (!sim.current_node()->isLeaf()) {
+#ifndef SAMPLE_WITH_PROB_EVAL
+							const auto node = sim.current_node();
+							const double V = node->eval;
+							const auto child = sim.select_child();
+							if (child->isLeaf())break;
+							const double Q = -child->eval;
+							c *= (Q - V) / T + 1;
+#else
+							const auto node = sim.current_node();
+							const double V = LearnUtil::EvalToProb(node->eval);
+							const auto child = sim.select_child();
+							if (child->isLeaf())break;
+							const double Q = LearnUtil::EvalToProb(-node->eval);
+							c *= (Q - V) / LearnUtil::change_evalTs_to_probTs(SearchTemperature::Te) + 1;
+#endif	
+							sim.proceed_to_child(child);
+							sim.proceed_to_child(sim.select_child());
+#ifdef LEARN_PG
+							if (pge_first_child) {
+								if (child->eval > pge_min_eval) {
+									pge_P = -std::exp(-(child->eval - pge_min_eval) / T) / pge_Z;
+								}
+								else {
+									pge_P = 1 - 1.0 / pge_Z;
+								}
+								pge_invc = 1.0 / c;
+								pge_first_child = false;
+							}
+#endif
+						}
+						//std::cout << c << " "; //dbg
+						dv.addGrad(c, sim.player);
+#ifdef LEARN_PG
+						dw_pg.addGrad(pge_P * c * pge_invc, sim.player);
+#endif
+					}
+					dv *= 1.0 / samplingnum;
+					eval = LearnUtil::EvalToProb(tree.getRoot()->eval);
+				}
+#endif
+#ifdef PVLEAF_GRAD
+#if defined(LEARN_TD_LAMBDA) || defined(LEARN_REGRESSION)
+				{	//PV-Leafによる勾配
+					const SearchNode* node = tree.getRoot();
+					SearchPlayer player = rootplayer;
+					int depth = 0;
+					while (!node->isLeaf()) {
+						//二手ずつ進める (相手番が末端になっていればその手前で終了)
+						const SearchNode* const child = LearnUtil::choiceBestChild(node);
+						if (child->isLeaf()) break;
+						player.proceed(child->move);
+						node = LearnUtil::choiceBestChild(child);
+						player.proceed(node->move);
+						depth++;
+					}
+					dv.addGrad(1, player);
+					eval = LearnUtil::EvalToProb(Evaluator::evaluate(player));
+					std::cout << "(d:" << depth << ") ";
+				}
+#endif
+#ifdef LEARN_PG
+				{//PG-Leaf
+					LearnVec e_omega;
+					double Z, min_eval;
+					Z = LearnUtil::getChildrenZ(tree.getRoot(), T, min_eval);
+					const auto& root = tree.getRoot();
+					const auto& nextmove = kifu.moves[t];
+
+					for (const auto& child : root->children) {
+						SearchPlayer player = tree.getRootPlayer();
+						player.proceed(child.move);
+						const SearchNode* node = &child;
+
+						while (!node->isLeaf()) {
+							const SearchNode* const next = LearnUtil::choiceBestChild(node);
+							if (next->isLeaf()) break;
+							player.proceed(next->move);
+							node = LearnUtil::choiceBestChild(next);
+							player.proceed(next->move);
+						}
+
+						const double pi = std::exp(-(child.eval - min_eval) / T) / Z;
+						if (child.move == nextmove) {	
+							e_omega.addGrad(1.0 - pi, player);
+						}
+						else {
+							e_omega.addGrad(-pi, player);
+						}
+					}
+
+					dw_pg += 1.0 / T * e_omega;
+				}
+#endif
+#endif //#ifdef PVLEAF_GRAD
+#else //#ifndef SEARCH_WITH_SAMPLING
+				//探索中サンプリング
+				std::cout << "s ";
+				LearnVec dv;
+				double eval;
+
+				std::cout << "l ";
+#endif //#ifndef SEARCH_WITH_SAMPLING
+
+				//学習
+#ifdef LEARN_TD_LAMBDA
+				{	//TD
+					if (!td_first) {
+						const double delta = gamma * eval - Vt_1;
+						dw_td += delta * e_vec;
+					}
+					else {
+						td_first = false;
+					}
+					Vt_1 = eval;
+					e_vec *= gamma * lambda;
+					e_vec += dv;
+				}
+#endif
+#ifdef LEARN_REGRESSION
+				{	//回帰
+					const double Pwin = LearnUtil::EvalToProb(eval);
+					dw_reg += (reg_r - Pwin) / LearnUtil::probT * (1 - Pwin) * Pwin * dv;
+					std::cout << "reg(" << ((reg_r - Pwin) / LearnUtil::probT * (1 - Pwin) * Pwin) << ") ";
+				}
+#endif
+
+			}
+			//一手進める
+			if (t >= kifu.moves.size()) break;
+			std::cout << kifu.moves[t].toUSI() << " ";
+			history.push_back(kifu.moves[t]);
+			tree.set(kifu.startpos, history);
+		}
+		std::cout << "gameover" << std::endl;
+		//終局の学習
+#ifdef LEARN_TD_LAMBDA
+		{	//TD
+			const auto& player = tree.getRootPlayer();
+			const double eval = LearnUtil::EvalToProb(Evaluator::evaluate(player));
+			const double r = LearnUtil::ResultToReward(kifu.result, kifu.teban, td_r_win, td_r_draw, td_r_lose);
+			const double delta = r + gamma * eval - Vt_1;
+			dw_td += delta * e_vec;
+			dw += alpha * dw_td;
+		}
+#endif
+#ifdef LEARN_PG
+		dw += pg_epsilon * pg_r * dw_pg;
+#endif
+#ifdef LEARN_REGRESSION
+		dw += reg_epsilon * dw_reg;
+#endif
+
+		//保存 
+		batch++;
+		if (batch >= bat_max) {
+			batch = 0;
+			dw.updateEval();
+			Evaluator::save();
+			itr++;
+		}
+		SaveTempVec(dw);
+		SaveTempInfo(itr, batch, itr_max, bat_max, datestr);
+		std::cout << "learning end." << std::endl;
+		std::cout << "continue? (y/n)> " << std::endl;
+		std::string str;
+		std::getline(std::cin, str);
+		if (str != "y") break;
+	}
+}
+
+bool Learner::LoadTempInfo(int& itr, int& batch, int& itr_max, int& bat_max, std::string& datestr, const std::string& dir) {
+	std::ifstream fs(dir + "/.learninfo");
+	if (fs) {
+		std::getline(fs, datestr);
+		std::string buff;
+		std::getline(fs, buff);
+		itr = std::stoi(buff);
+		std::getline(fs, buff);
+		batch = std::stoi(buff);
+		std::getline(fs, buff);
+		itr_max = std::stoi(buff);
+		std::getline(fs, buff);
+		bat_max = std::stoi(buff);
+		return true;
+	}
+	else {
+		return false;
+	}
+}
+
+bool Learner::SaveTempInfo(int itr, int batch, int itr_max, int bat_max, const std::string& datestr, const std::string& dir) {
+	std::filesystem::create_directories(dir);
+	std::ofstream fs(dir + "/.learninfo");
+	if (fs.is_open()) {
+		fs << datestr << "\n";
+		fs << itr << "\n";
+		fs << batch << "\n";
+		fs << itr_max << "\n";
+		fs << bat_max << "\n";
+		return true;
+	}
+	else {
+		return false;
+	}
+}
+
+bool Learner::LoadTempVec(LearnVec &vec, const int vecnum, const std::string& dir) {
+	const std::string filepath = dir + "/.learngrad" + std::to_string(vecnum);
+	if (!std::filesystem::exists(filepath)) return false;
+	vec.load(filepath);
+	return true;
+}
+
+bool Learner::SaveTempVec(LearnVec& vec, const int vecnum, const std::string& dir) {
+	std::filesystem::create_directories(dir);
+	vec.save(dir + "/.learngrad" + std::to_string(vecnum));
+	return true;
+}
+
+
+void Learner::test() {
+	LearnVec vec;
+	Kyokumen k;
+	SearchPlayer player(k);
+	vec.addGrad(20, player);
+	{
+		LearnVec _tvec;
+		_tvec += vec;
+		SaveTempVec(_tvec, 2);
+	}
+	{
+		LearnVec _tvec;
+		LoadTempVec(_tvec, 2);
+		if (_tvec == vec) {
+			std::cout << "save-load is ok\n";
+		}
+		else {
+			_tvec.print(15, true);
+			vec.print(15, true);
+			_tvec.print(15, false);
+			vec.print(15, false);
+			std::cout << "save-load is ng\n";
+		}
+	}
+}

--- a/FiveSquareShogi/learner.h
+++ b/FiveSquareShogi/learner.h
@@ -1,37 +1,76 @@
 ﻿#pragma once
 #include "learn_util.h"
-#include "agent.h"
+#include "learn_agent.h"
 #include "learn_method.h"
+
+class Kifu {
+public:
+	Kyokumen startpos;
+	std::vector<Move> moves;
+	bool teban;
+	GameResult result;
+
+	void read_from_command();
+};
 
 class Learner {
 public:
 	static void execute();
 
 private:
+	bool enable = true;
+
 	void init(const std::vector<std::string>& cmdtokens);
+	static void coutOption();
+	void setOption(const std::vector<std::string>& token);
+
 	void search(SearchTree& tree);
 	void search(SearchTree& tree, const std::chrono::milliseconds time);
+	void search(SearchTree& tree, const long long simulate_num);
 	static int getWinner(std::vector<std::string>& sfen);
 
 	void learn_start_by_randompos(int batch,int itr);
+	
+	void lbk_options();
+	void learn_by_kifu();
+
+	void test();
+
+	static bool LoadTempInfo(int& itr, int& batch, int& itr_max, int& bat_max, std::string& datestr, const std::string& dir = "./learning");
+	static bool SaveTempInfo(int itr, int batch, int itr_max, int bat_max,const std::string& datestr, const std::string& dir = "./learning");
+	static bool LoadTempVec(LearnVec& vec, const int vecnum = 1, const std::string& dir = "./learning/");
+	static bool SaveTempVec(LearnVec& vec, const int vecnum = 1, const std::string& dir = "./learning/");
 
 	double T_search = 200;
 	double T_selfplay = 120;
 	std::chrono::milliseconds searchtime{ 1000 };
 	int agentnum = 8;
+	LearnAgentPool agents;
 
 	double child_pi_limit = 0.00005;
 	double samplingrate = 0.1;
 
-	double learning_rate_td = 0.1;
+	long long int batch_size = 1;
+
+	long long unsigned samplingnum = 10000;
+
+	double learning_rate_td = 0.01;
 	double learning_rate_pp = 0.1;
 	double learning_rate_bts = 0.1;
 	double learning_rate_reg = 0.1;
-	double learning_rate_pge = 0.1;
+	double learning_rate_pg = 0.1;
 	double learning_rate_bts_sampling = 0.1;
 
+	double td_r_win = 1;
+	double td_r_draw = 0;
+	double td_r_lose = -1;
+	
 	double td_gamma = 0.95;
 	double td_lambda = 0.9;
+
+	double pg_r_win = 1;
+	double pg_r_draw = 0;
+	double pg_r_lose = -1;
 
 	friend class ShogiTest;
 };

--- a/FiveSquareShogi/main.cpp
+++ b/FiveSquareShogi/main.cpp
@@ -3,6 +3,7 @@
 #include "stdafx.h"
 #include "commander.h"
 #include "learner.h"
+#include "learn_commander.h"
 #include "stest.h"
 #include <iostream>
 
@@ -12,7 +13,11 @@ int main(int argc, char* argv[])
 #ifndef _LEARN
     Commander::execute(enginename);
 #else
+#ifndef _LEARN_COMMANDER
     Learner::execute();
+#else
+    LearnCommander::execute();
+#endif
 #endif
     //ShogiTest::test();
 }

--- a/FiveSquareShogi/node.h
+++ b/FiveSquareShogi/node.h
@@ -41,6 +41,8 @@ private:
 	static double mateScore;
 	static double mateScoreBound;
 	static double mateOneScore;
+	static double midRepScore;
+	static double drawScore;
 	static int QS_depth;
 	static int Es_FunctionCode;
 	static double Es_c;
@@ -54,6 +56,7 @@ public:
 	static void setMateOneScore(const double score) { mateOneScore = score; }
 	static double getMateScoreBound() { return mateScoreBound; }
 	static double getMateScore() { return mateScore; }
+	static void setFirstRepetitonToMateScore(bool b);
 	static void setQSearchDepth(const double mmqs) { QS_depth = mmqs; }
 	static double getQSdepth() { return QS_depth; }
 	static void setEsFuncCode(const int code) { Es_FunctionCode = code; }
@@ -72,11 +75,15 @@ public:
 	void setEvaluation(const double evaluation) { eval = evaluation; }
 	void setMass(const double m) { mass = m; }
 
+	void setExpanded();
 	void setMateVariation(const double childmin);
 	void setMate();
 	void setDeclare();
+	void setDraw(const bool teban);
 	void setRepetition(const bool teban);
+	void setRepetitiveEnd(const bool teban);
 	void setRepetitiveCheck();
+	void setRepetitiveCheckmate();
 	void setOriginEval(const double evaluation) { origin_eval = evaluation; }
 
 	std::size_t getOffspringsCount()const;
@@ -86,6 +93,7 @@ public:
 	bool isTerminal()const { return status == State::T || status == State::R; }
 	bool isRepetition()const { return status == State::R; }
 	bool isSearchable()const { const auto s = status.load(); return s == State::N || s == State::E; }
+	bool isMate()const { return std::abs(eval) >= mateScoreBound; }
 	double getEs()const { return getEs(Es_FunctionCode); }
 	double getEs(int funccode)const;
 	SearchNode* getBestChild()const { return getBestChild(PV_FuncCode); }

--- a/FiveSquareShogi/random.cpp
+++ b/FiveSquareShogi/random.cpp
@@ -1,0 +1,96 @@
+﻿#include "random.h"
+#include <limits>
+#include <random>
+
+namespace Random {
+	xoshiro256p::xoshiro256p() {
+		std::random_device rd;
+		std::uniform_int_distribution urandom(std::numeric_limits<u64>::min(), std::numeric_limits<u64>::max());
+		s[0] = urandom(rd);
+		s[1] = urandom(rd);
+		s[2] = urandom(rd);
+		s[3] = urandom(rd);
+	}
+	xoshiro256p::xoshiro256p(u64 a, u64 b, u64 c, u64 d)
+		:s({ a,b,c,d })
+	{}
+	xoshiro256p::xoshiro256p(const xoshiro256p& x)
+		: s(x.s)
+	{}
+	xoshiro256p::xoshiro256p(xoshiro256p&& x) noexcept
+		:s(std::move(x.s))
+	{}
+
+	double xoshiro256p::rand01() {
+		return static_cast<double>(next()) / std::numeric_limits<u64>::max();
+	}
+	double xoshiro256p::randMinMax(double min, double max) {
+		return min + rand01() * (max - min);
+	}
+
+	u64 xoshiro256p::next() {
+		const u64 result = s[0] + s[3];
+
+		const u64 t = s[1] << 17;
+
+		s[2] ^= s[0];
+		s[3] ^= s[1];
+		s[1] ^= s[2];
+		s[0] ^= s[3];
+
+		s[2] ^= t;
+
+		s[3] = rotl(s[3], 45);
+
+		return result;
+	}
+
+	void xoshiro256p::jump() {
+		static constexpr u64 JUMP[] = { 0x180ec6d33cfd0aba, 0xd5a61266f0c9392c, 0xa9582618e03fc9aa, 0x39abdc4529b1661c };
+
+		u64 s0 = 0;
+		u64 s1 = 0;
+		u64 s2 = 0;
+		u64 s3 = 0;
+		for (int i = 0; i < sizeof JUMP / sizeof * JUMP; i++)
+			for (int b = 0; b < 64; b++) {
+				if (JUMP[i] & UINT64_C(1) << b) {
+					s0 ^= s[0];
+					s1 ^= s[1];
+					s2 ^= s[2];
+					s3 ^= s[3];
+				}
+				next();
+			}
+
+		s[0] = s0;
+		s[1] = s1;
+		s[2] = s2;
+		s[3] = s3;
+	}
+
+	void xoshiro256p::long_jump() {
+		static constexpr u64 LONG_JUMP[] = { 0x76e15d3efefdcbbf, 0xc5004e441c522fb3, 0x77710069854ee241, 0x39109bb02acbe635 };
+
+		u64 s0 = 0;
+		u64 s1 = 0;
+		u64 s2 = 0;
+		u64 s3 = 0;
+		for (int i = 0; i < sizeof LONG_JUMP / sizeof * LONG_JUMP; i++)
+			for (int b = 0; b < 64; b++) {
+				if (LONG_JUMP[i] & UINT64_C(1) << b) {
+					s0 ^= s[0];
+					s1 ^= s[1];
+					s2 ^= s[2];
+					s3 ^= s[3];
+				}
+				next();
+			}
+
+		s[0] = s0;
+		s[1] = s1;
+		s[2] = s2;
+		s[3] = s3;
+	}
+
+}

--- a/FiveSquareShogi/random.h
+++ b/FiveSquareShogi/random.h
@@ -1,0 +1,33 @@
+﻿#pragma once
+#include <cstdint>
+#include <array>
+
+namespace Random {
+	using u64 = std::uint64_t;
+
+	/*
+	xorshift256+ という高速な乱数生成器
+	[0,1]の浮動小数点で利用する前提になっていて、
+	下位ビットの精度を低くする代わりに生成速度を高速化している
+	整数として使用する場合はxorshift256++等を使用する
+	引用元： https://prng.di.unimi.it/
+	*/
+	class xoshiro256p {
+	public:
+		xoshiro256p();
+		xoshiro256p(u64 a, u64 b, u64 c, u64 d);
+		xoshiro256p(const xoshiro256p& x);
+		xoshiro256p(xoshiro256p&& x)noexcept;
+		double rand01();
+		double randMinMax(double min, double max);
+
+		u64 next();
+		void jump();
+		void long_jump();
+		static inline u64 rotl(const u64 x, int k) {
+			return (x << k) | (x >> (64 - k));
+		}
+	private:
+		std::array<u64, 4> s;
+	};
+}

--- a/FiveSquareShogi/simulation.cpp
+++ b/FiveSquareShogi/simulation.cpp
@@ -1,0 +1,340 @@
+﻿#include "stdafx.h"
+#include "simulation.h"
+#include "leaf_guard.h"
+
+int Simulation::drawmovenum = 320;
+Random::xoshiro256p Simulation::rand_parent{ 0x1234567ULL,0x928AC12ULL,0x8FE4561199ULL,0xC123ABDDD1ULL };
+
+Simulation::Simulation(SearchTree& tree, const double T_s) 
+	:Simulation(tree, T_s, rand_parent)
+{
+	rand_parent.jump();
+}
+
+Simulation::Simulation(SearchTree& tree, const double T_s, Random::xoshiro256p rand)
+	: tree(tree), player(tree.getRootPlayer()), T_s(T_s), rand(rand)
+{
+	search_enable = true;
+}
+
+void Simulation::init() {
+	history.clear();
+	history.push_back(tree.getRoot());
+	k_history.clear();
+	player = tree.getRootPlayer();
+}
+
+
+void Simulation::simulate() {
+	init();
+	if (!search_enable) return;
+	select();
+	if (!search_enable) return;
+	expand();
+	backup();
+}
+
+void Simulation::select() {
+	SearchNode* node = current_node();
+	while (!node->isLeaf()) {
+		if (!search_enable) return;
+		node = select_child();
+		proceed_to_child(node);
+	}
+}
+
+SearchNode* Simulation::select_child() {
+	using dn = std::pair<double, SearchNode*>;
+
+	SearchNode* const node = current_node();
+	double CE = std::numeric_limits<double>::max();
+	std::vector<dn> evals; evals.reserve(node->children.size());
+	for (auto& child : node->children) {
+		if (child.isSearchable()) {
+			double eval = child.getEs();
+			evals.push_back(std::make_pair(eval, &child));
+			if (eval < CE) {
+				CE = eval;
+			}
+		}
+	}
+	if (evals.empty()) {
+		//node->status = SearchNode::State::Terminal;
+		if (history.size() == 1) {
+			using namespace std::chrono_literals;
+			std::this_thread::sleep_for(200us);
+		}
+		return nullptr;
+	}
+	const double T_c = SearchTemperature::getTs_atNode(T_s, *node);
+	double Z = 0;
+	for (const auto& eval : evals) {
+		Z += std::exp(-(eval.first - CE) / T_c);
+	}
+	double pip = Z * rand.rand01();
+	SearchNode* next = evals.front().second;
+	for (const auto& eval : evals) {
+		pip -= std::exp(-(eval.first - CE) / T_c);
+		if (pip <= 0) {
+			next = eval.second;
+			break;
+		}
+	}
+	return next;
+}
+
+SearchNode* Simulation::select_bestchild() const {
+	const SearchNode* const node = current_node();
+	const auto& children = node->children;
+	if (children.empty()) return nullptr;
+	SearchNode* bestchild = children.begin();
+	for (auto child = children.begin(); child != children.end(); child++) {
+		if (child->eval < bestchild->eval) {
+			bestchild = child;
+		}
+	}
+	return bestchild;
+}
+
+void Simulation::proceed_to_child(SearchNode* const child) {
+	//局面を進める
+	k_history.push_back(std::make_pair(player.kyokumen.getHash(), player.kyokumen.getBammen()));
+	player.proceed(child->move);
+	history.push_back(child);
+}
+
+void Simulation::expand() {
+	const double T_e = SearchTemperature::Te;
+	SearchNode* const node = current_node();
+	LeafGuard dredear(node);
+	if (!dredear.Result()) {
+		return;
+	}
+
+	{//子ノード生成
+		const auto moves = MoveGenerator::genMove(node->move, player.kyokumen);
+		if (moves.empty()) {
+			node->setMate();
+			return;
+		}
+		else if (history.size() - 1 + tree.getMoveNum() >= drawmovenum) {
+			node->setDraw(player.kyokumen.teban());
+			return;
+		}
+		node->addChildren(moves);
+	}
+
+	uint64_t evalcount = 0ull;
+	for (auto& child : node->children) {
+		const auto cache = player.proceedC(child.move);
+		if (!checkRepetiton(&child, player.kyokumen, history, k_history)) {
+			evalcount += qsearch(&child, player, history.size());
+		}
+		player.recede(child.move, cache);
+	}
+	tree.addEvaluationCount(evalcount);
+	//sortは静止探索後の方が評価値順の並びが維持されやすい　親スタートの静止探索ならその前後共にsortしてもいいかもしれない
+	node->children.sort();
+	//sortしたので一番上が最小値になっているはず
+	double emin = node->children.begin()->eval;
+	double Z_e = 0;
+	for (const auto& child : node->children) {
+		Z_e += std::exp(-(child.eval - emin) / T_e);
+	}
+	double E = 0;
+	for (const auto& child : node->children) {
+		E -= child.eval * std::exp(-(child.eval - emin) / T_e) / Z_e;
+	}
+	node->setEvaluation(E);
+	node->setMass(1);
+}
+
+std::size_t Simulation::qsearch(SearchNode* const root, SearchPlayer& player, const int kifulength) {
+	const int& depth = SearchNode::getQSdepth();
+	if (depth <= 0) {
+		const double eval = Evaluator::evaluate(player);
+		root->setEvaluation(eval);
+		root->setOriginEval(eval);
+		return 1ull;
+	}
+	auto moves = MoveGenerator::genCapMove(root->move, player.kyokumen);
+	if (moves.empty()) {
+		if (root->move.isOute()) {
+			root->setMate();
+			return 1ull;
+		}
+		else {
+			const double eval = Evaluator::evaluate(player);
+			root->setEvaluation(eval);
+			root->setOriginEval(eval);
+			return 1ull;
+		}
+	}
+	else if (kifulength - 1 + tree.getMoveNum() >= drawmovenum) {
+		root->setDraw(player.kyokumen.teban());
+		return 1ull;
+	}
+	double max = Evaluator::evaluate(player);
+	evalcount = 1;
+	for (auto& m : moves) {
+		const FeatureCache cache = player.feature.getCache();
+		const koma::Koma captured = player.proceed(m);
+		const double eval = -alphabeta(m, player, depth - 1, std::numeric_limits<double>::lowest(), -max);
+		if (eval > max) {
+			max = eval;
+		}
+		player.recede(m, captured, cache);
+	}
+	root->setEvaluation(max);
+	root->setOriginEval(max);
+	return evalcount;
+}
+
+void Simulation::backup() {
+	using dd = std::pair<double, double>;
+	const double MateScoreBound = SearchNode::getMateScoreBound();
+	const double T_e = SearchTemperature::Te;
+	const double T_d = SearchTemperature::Td;
+
+	for (int i = history.size() - 2; i >= 0; i--) {
+		SearchNode* const node = history[i];
+		double emin = std::numeric_limits<double>::max();
+		std::vector<dd> emvec; emvec.reserve(node->children.size());
+		for (const auto& child : node->children) {
+			const double eval = child.getEvaluation();
+			const double mass = child.mass;
+			emvec.push_back(std::make_pair(eval, mass));
+			if (eval < emin) {
+				emin = eval;
+			}
+		}
+		if (std::abs(emin) > MateScoreBound) {
+			node->setMateVariation(emin);
+		}
+		else {
+			double Z_e = 0;
+			double Z_d = 0;
+			for (const auto& em : emvec) {
+				const double eval = em.first;
+				Z_e += std::exp(-(eval - emin) / T_e);
+				Z_d += std::exp(-(eval - emin) / T_d);
+			}
+			double E = 0;
+			double M = 1;
+			for (const auto& em : emvec) {
+				const double eval = em.first;
+				const double mass = em.second;
+				E -= eval * std::exp(-(eval - emin) / T_e) / Z_e;
+				M += mass * std::exp(-(eval - emin) / T_d) / Z_d;
+			}
+			node->setEvaluation(E);
+			node->setMass(M);
+		}
+	}
+}
+
+double Simulation::alphabeta(Move& pmove, SearchPlayer& player, int depth, double alpha, double beta) {
+	evalcount++;
+	const auto eval = Evaluator::evaluate(player);
+	if (depth <= 0) {
+		return eval;
+	}
+	alpha = std::max(eval, alpha);
+	if (alpha >= beta) {
+		return alpha;
+	}
+	auto moves = MoveGenerator::genCapMove(pmove, player.kyokumen);
+	if (moves.empty() || pmove.isOute()) {
+		return eval;
+	}
+	for (auto& m : moves) {
+		const FeatureCache cache = player.feature.getCache();
+		const koma::Koma captured = player.proceed(m);
+		alpha = std::max(-alphabeta(m, player, depth - 1, -beta, -alpha), alpha);
+		player.recede(m, captured, cache);
+		if (alpha >= beta) {
+			return alpha;
+		}
+	}
+	return alpha;
+}
+
+
+bool Simulation::checkRepetiton(SearchNode* const node, const Kyokumen& kyokumen, const std::vector<SearchNode*>& history, const std::vector<std::pair<std::uint64_t, Bammen>>& k_history) {
+	unsigned repnum = 0;
+	SearchNode* repnode = nullptr;
+	SearchNode* latestRepnode = nullptr;
+
+
+	auto p = tree.findRepetition(kyokumen);
+	repnum += p.first;
+	repnode = p.second;
+	const auto hash = kyokumen.getHash();
+	//先後一致している方のみを調べればよいので1つ飛ばしで調べる
+	for (int t = k_history.size() - 2; t >= 0; t -= 2) {
+		const auto& k = k_history[t];
+		if (k.first == hash && k.second == kyokumen.getBammen()) {
+			repnum++;
+			repnode = history[t];
+			if (latestRepnode == nullptr) {
+				latestRepnode = repnode;
+			}
+		}
+	}
+	if (latestRepnode == nullptr) {
+		latestRepnode = repnode;
+	}
+
+	if (repnum > 0/*千日手である*/) {
+		if (repnum >= 3) {
+			//同一局面が4回繰り返されているなら、ゲーム終了
+			if (checkRepetitiveCheck(kyokumen, history, latestRepnode)) {
+				node->setRepetitiveCheckmate();
+			}
+			else {
+				node->setRepetitiveEnd(kyokumen.teban());
+			}
+		}
+		else {
+			//繰り返し回数が少ない場合は、評価値を千日手にする
+			if (checkRepetitiveCheck(kyokumen, history, latestRepnode)) {
+				node->setRepetitiveCheck();
+			}
+			else {
+				node->setRepetition(kyokumen.teban());
+			}
+		}
+		return true;
+	}
+	return false;
+}
+
+bool Simulation::checkRepetitiveCheck(const Kyokumen& kyokumen, const std::vector<SearchNode*>& searchhis, const SearchNode* const repnode)const {
+	//対象ノードは未展開なので局面から王手かどうか判断する この関数は4回目の繰り返しの終端ノードで呼ばれているのでkusemonoを何回も生成するような無駄は発生していない
+	if (!searchhis.back()->move.isOute()) {
+		if (!kyokumen.isOute(searchhis.back()->move)) {
+			return false;
+		}
+		searchhis.back()->move.setOute(true);
+	}
+	//過去ノードはmoveのouteフラグから王手だったか判定する
+	int t;
+	for (t = searchhis.size() - 3; t >= 0; t -= 2) {//historyの後端は末端ノードなのでその二つ前から調べていく
+		if (!searchhis[t]->move.isOute()) {
+			return false;
+		}
+		if (searchhis[t] == repnode) {
+			return true;
+		}
+	}
+	const auto& treehis = tree.getHistory();
+	for (t += treehis.size() - 1; t >= 0; t -= 2) {
+		if (!treehis[t]->move.isOute()) {
+			return false;
+		}
+		if (treehis[t] == repnode) {
+			return true;
+		}
+	}
+	return false;
+}

--- a/FiveSquareShogi/simulation.h
+++ b/FiveSquareShogi/simulation.h
@@ -1,0 +1,50 @@
+﻿#pragma once
+#include "tree.h"
+#include "move_gen.h"
+#include "kppt_evaluate.h"
+#include "temperature.h"
+#include "random.h"
+#include <random>
+#include <thread>
+#include <functional>
+
+class Simulation {
+public:
+	static void setDrawMoveNum(int n) { drawmovenum = n; }
+private:
+	static int drawmovenum;
+	static Random::xoshiro256p rand_parent;
+
+public:
+	Simulation(SearchTree& tree):Simulation(tree, SearchTemperature::getTs(0)){}
+	Simulation(SearchTree& tree, const double T_s);
+	Simulation(SearchTree& tree, const double T_s, Random::xoshiro256p rand);
+
+	void init();
+	void simulate();
+	void select();
+	SearchNode* current_node()const { return history.back(); }
+	SearchNode* select_child();
+	SearchNode* select_bestchild() const;
+	void proceed_to_child(SearchNode* const child);
+	void expand();
+	void backup();
+	std::size_t qsearch(SearchNode* const root, SearchPlayer& player, int kifulength);
+	double alphabeta(Move&, SearchPlayer&, int depth, double alpha, double beta);
+	bool checkRepetiton(SearchNode* const node, const Kyokumen& kyokumen, const std::vector<SearchNode*>& history, const std::vector<std::pair<std::uint64_t, Bammen>>& k_history);
+	bool checkRepetitiveCheck(const Kyokumen& k, const std::vector<SearchNode*>& searchhis, const SearchNode* const latestRepnode)const;
+	
+	SearchTree& tree;
+	SearchPlayer player;
+	double T_s;
+	std::vector<SearchNode*> history;
+	std::vector<std::pair<uint64_t, Bammen>> k_history;
+	std::atomic_bool search_enable;
+	std::uint64_t evalcount = 0;
+	Random::xoshiro256p rand;
+
+	/*
+	温度：simulate毎に渡せばよろしい
+
+	*/
+};

--- a/FiveSquareShogi/stest.cpp
+++ b/FiveSquareShogi/stest.cpp
@@ -33,25 +33,49 @@ void ShogiTest::test() {
 	BBkiki::init();
 	Evaluator::init();
 	std::cout << "initialized." << std::endl;
+#if 1
+	{
+		std::string sfen = "position startpos moves 3e3d 4a5b 3d2c 5b4a 3d2c";
+		Kyokumen kyokumen(usi::split(sfen, ' '));
+		kyokumen.proceed(Move(14, 13, false));
+		kyokumen.proceed(Move(15, 21, false));
+		kyokumen.proceed(Move(13, 7, false));
+		kyokumen.proceed(Move(21, 15, false));
+		kyokumen.proceed(Move(9, 17, false));
+		Move move(9, 17, false);
+		const auto moves = MoveGenerator::genMove(move, kyokumen);
+		for (const auto m : moves) {
+			std::cout << m.toUSI() << " ";
+		}
+		std::cout << std::endl;
+	}
+#endif
 #if 0
 	{
 		Learner lrn;
 		LearnVec v;
 		v.KKP[15] = 12.35;
+		v.KKP[14] = 21.2;
 		v.KPP[66] = -9.2;
-		v.showLearnVec_kkpt(0.1);
-		v.showLearnVec_kppt(0.1);
+		v.print(0.1, 1);
+		v.print(0.1, 0);
 		v.save("test.bin");
 		LearnVec e;
 		e.load("test.bin");
-		e.showLearnVec_kkpt(0.1);
-		e.showLearnVec_kppt(0.1);
+		v.print(0.1, 1);
+		v.print(0.1, 0);
 		e += v;
-		e.showLearnVec_kkpt(0.1);
-		e.showLearnVec_kppt(0.1);
+		e.print(0.1, 1);
+		e.print(0.1, 0);
+		LearnOpt adam;
+		for (int i = 0; i < 100; i++) {
+			adam.updateEval(e);
+			e += 2 * v;
+		}
+		//coutKPP();
+		
 	}
 #endif
-	coutKPP();
 #if 0
 	checkGenMove("position startpos");
 	checkGenMove("position startpos moves 4e4d");

--- a/FiveSquareShogi/tree.h
+++ b/FiveSquareShogi/tree.h
@@ -28,7 +28,8 @@ public:
 	const SearchPlayer& getRootPlayer()const { return rootPlayer; }
 	std::pair<unsigned, SearchNode*> findRepetition(const Kyokumen& kyokumen)const;//過去に同一局面が無かったか検索する なければ-1を返す
 	SearchNode* getRoot() const { return history.back(); }
-	SearchNode* getGameRoot() const { return history.front(); }
+	SearchNode* getGameRoot() const { if (!history.empty()) return history.front(); else return nullptr; }
+	const Kyokumen& getGameStartKyokumen() const { return startKyokumen; }
 	int getMoveNum() const { return history.size() - 1; }
 
 	void foutTree()const;
@@ -50,5 +51,7 @@ private:
 	std::mutex mtx_deleteTrees;
 
 	friend class Commander;
+	friend class Learner;
+	friend class LearnCommander;
 	friend class ShogiTest;
 };

--- a/FiveSquareShogi/usi.cpp
+++ b/FiveSquareShogi/usi.cpp
@@ -82,5 +82,18 @@ namespace usi {
 		return tokens;
 	}
 
+	std::string combine(std::vector<std::string>::const_iterator begin, const std::vector<std::string>::const_iterator end, char splitter) {
+		std::string str;
+		auto it = begin;
+		while (it != end) {
+			str += *it;
+			it++;
+			if (it != end) {
+				str += splitter;
+			}
+		}
+		return str;
+	}
+
 	std::string btos(bool b) { return b ? "true" : "false"; }
 }

--- a/FiveSquareShogi/usi.h
+++ b/FiveSquareShogi/usi.h
@@ -17,4 +17,5 @@ namespace usi {
 	extern std::string posToUsi(const koma::Position pos);
 	extern char tebanToUsi(bool teban);
 	extern std::vector<std::string> split(const std::string& str, char splitter);
+	extern std::string combine(std::vector<std::string>::const_iterator begin, const std::vector<std::string>::const_iterator end, char splitter);
 }


### PR DESCRIPTION
主な更新点
・対局しながら学習をするクラスLearnCommanderを作成（PV-Leafかサンプリング勾配で、TD(λ)法, PG法, 回帰法, ブートストラップ法に対応）
・Learnerをusi setoptionや棋譜学習に対応させた
・高速な乱数生成のためのクラスを作成
・評価関数の型を浮動小数点型にするオプションを追加
・駒価値をパラメータ化する処理/オプションを追加
・バグ修正
・その他細かい機能追加